### PR TITLE
apply updaters

### DIFF
--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -114,6 +114,7 @@ class State(object):
             return
         keys, values = npize(update)
         index = self.index_for(keys)
+        state_dict = dict(zip(self.keys,self.state))
 
         for index, key, value in zip(index, keys, values):
             # updater can be a function or a key into the updater library
@@ -123,7 +124,7 @@ class State(object):
 
             self.state[index], other_updates = updater(
                 key,
-                dict(zip(self.keys,self.state)),
+                state_dict,
                 self.state[index],
                 value)
 

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -4,6 +4,9 @@ import collections
 import numpy as np
 import lens.actor.emitter as emit
 
+
+target_key = '__target'
+
 def npize(d):
     ''' Turn a dict into an ordered set of keys and values. '''
 
@@ -13,11 +16,14 @@ def npize(d):
 
     return keys, values
 
-def update_delta(current_value, new_value):
-    return current_value + new_value
+def update_delta(key, current_value, new_value):
+    return current_value + new_value, {}
 
-def update_set(current_value, new_value):
-    return new_value
+def update_set(key, current_value, new_value):
+    return new_value, {}
+
+def update_target(key, current_value, new_value):
+    return current_value, {key+target_key: new_value}
 
 updater_library = {
     'delta': update_delta,
@@ -107,7 +113,9 @@ class State(object):
             updater = self.updaters.get(key, 'delta')
             if not callable(updater):
                 updater = updater_library[updater]
-            self.state[index] = updater(self.state[index], value)
+            self.state[index], other_updates = updater(key, self.state[index], value)
+            for other_key, other_value in other_updates.iteritems():
+                self.state[other_key] = other_value
 
     def apply_updates(self, updates):
         ''' Apply a list of updates to the state '''
@@ -144,6 +152,9 @@ class Process(object):
         return {}
 
     def default_emitter_keys(self):
+        return {}
+
+    def default_updaters(self):
         return {}
 
     # def default_parameters(self):
@@ -191,6 +202,21 @@ def connect_topology(processes, states, topology):
 
         process.assign_roles(roles)
 
+def merge_initial_states(processes):
+    initial_state = {}
+    for process_id, process in processes.iteritems():
+        default = process.default_state()
+        dict_merge(initial_state, default)
+    return initial_state
+
+def dict_merge(dct, merge_dct):
+    ''' Recursive dict merge '''
+    for k, v in merge_dct.iteritems():
+        if (k in dct and isinstance(dct[k], dict)
+                and isinstance(merge_dct[k], collections.Mapping)):
+            dict_merge(dct[k], merge_dct[k])
+        else:
+            dct[k] = merge_dct[k]
 
 class Compartment(object):
     ''' Track a set of processes and states and the connections between them. '''
@@ -281,21 +307,6 @@ class Compartment(object):
         self.emitter.emit(data)
 
 
-def merge_initial_states(processes):
-    initial_state = {}
-    for process_id, process in processes.iteritems():
-        default = process.default_state()
-        dict_merge(initial_state, default)
-    return initial_state
-
-def dict_merge(dct, merge_dct):
-    ''' Recursive dict merge '''
-    for k, v in merge_dct.iteritems():
-        if (k in dct and isinstance(dct[k], dict)
-                and isinstance(merge_dct[k], collections.Mapping)):
-            dict_merge(dct[k], merge_dct[k])
-        else:
-            dct[k] = merge_dct[k]
 
 def test_compartment():
     # simplest possible metabolism

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -17,17 +17,18 @@ def npize(d):
 
     return keys, values
 
-def update_delta(key, current_value, new_value):
+def update_delta(key, state, current_value, new_value):
     return current_value + new_value, {}
 
-def update_set(key, current_value, new_value):
+def update_set(key, state, current_value, new_value):
     return new_value, {}
 
-def update_target(key, current_value, new_value):
+def update_target(key, state, current_value, new_value):
     return current_value, {key + target_key: new_value}
 
-def accumulate_delta(key, current_value, new_value):
-    return current_value, {key + exchange_key: new_value}
+def accumulate_delta(key, state, current_value, new_value):
+    new_key = key + exchange_key
+    return current_value, {new_key: state[new_key] + new_value}
 
 updater_library = {
     'delta': update_delta,
@@ -119,7 +120,7 @@ class State(object):
             updater = self.updaters.get(key, 'delta')
             if not callable(updater):
                 updater = updater_library[updater]
-            self.state[index], other_updates = updater(key, self.state[index], value)
+            self.state[index], other_updates = updater(key, self.state, self.state[index], value)
 
             for other_key, other_value in other_updates.iteritems():
                 self.state[other_key] = other_value

--- a/lens/boot_compartment.py
+++ b/lens/boot_compartment.py
@@ -54,7 +54,7 @@ def wrap_initialize(make_process):
                 'database': 'simulations',
                 },
             'compartment_options':{
-                'time_step': 10.0,
+                'time_step': 1.0,
                 },
             })
         process = make_process(boot_config)  # 'boot_config', set in environment.control is the process' initial_parameters

--- a/lens/composites/Covert2008.py
+++ b/lens/composites/Covert2008.py
@@ -14,7 +14,6 @@ from lens.processes.division import Division
 
 def initialize_covert2008(config):
     config.update({
-        'exchange_key': '__exchange',  # key for counting exchange with lattice
         'emitter': {
             'type': 'database',
             'url': 'localhost:27017',

--- a/lens/composites/growth_division.py
+++ b/lens/composites/growth_division.py
@@ -11,7 +11,6 @@ from lens.processes.growth import Growth
 
 def initialize_growth_division(config):
     config.update({
-        'exchange_key': '__exchange',  # key for counting exchange with lattice
         'emitter': {
             'type': 'database',
             'url': 'localhost:27017',

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -96,7 +96,7 @@ def boot_glc_g6p_small(agent_id, agent_type, agent_config):
 
     media_id = 'GLC_G6P'
     make_media = Media()
-    timeline_str = '0 {}, 7200 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
+    timeline_str = '0 {}, 600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
     timeline = make_media.make_timeline(timeline_str)
 
     print("Media condition: {}".format(media_id))

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -96,7 +96,7 @@ def boot_glc_g6p_small(agent_id, agent_type, agent_config):
 
     media_id = 'GLC_G6P'
     make_media = Media()
-    timeline_str = '0 {}, 600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
+    timeline_str = '0 {}, 7200 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
     timeline = make_media.make_timeline(timeline_str)
 
     print("Media condition: {}".format(media_id))
@@ -110,8 +110,8 @@ def boot_glc_g6p_small(agent_id, agent_type, agent_config):
         'output_dir': output_dir,
         # 'concentrations': media,
         'run_for': 2.0,
-        'depth': 0.01, #0.0001,  # 3000 um is default
-        'edge_length': 10.0,
+        'depth': 1e-05, #0.0001,  # 3000 um is default
+        'edge_length': 1.0,
         'patches_per_edge': 1,
     }
 

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -110,7 +110,7 @@ def boot_glc_g6p_small(agent_id, agent_type, agent_config):
         'output_dir': output_dir,
         # 'concentrations': media,
         'run_for': 2.0,
-        'depth': 0.1, #0.0001,  # 3000 um is default
+        'depth': 0.01, #0.0001,  # 3000 um is default
         'edge_length': 10.0,
         'patches_per_edge': 1,
     }

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -96,7 +96,7 @@ def boot_glc_g6p_small(agent_id, agent_type, agent_config):
 
     media_id = 'GLC_G6P'
     make_media = Media()
-    timeline_str = '0 {}, 600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
+    timeline_str = '0 {}, 7200 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
     timeline = make_media.make_timeline(timeline_str)
 
     print("Media condition: {}".format(media_id))

--- a/lens/environment/lattice_compartment.py
+++ b/lens/environment/lattice_compartment.py
@@ -32,11 +32,9 @@ class LatticeCompartment(Compartment, Simulation):
     def generate_inner_update(self):
         environment = self.states.get(self.environment)
         if environment:
-            changes_keys = [state_id + self.exchange_key
-                            for state_id in self.environment_ids]
+            changes_keys = [state_id + self.exchange_key for state_id in self.environment_ids]
             changes = environment.state_for(changes_keys)
-            environment_change = {mol_id.replace(self.exchange_key, ''): value
-                                  for mol_id, value in changes.iteritems()}
+            environment_change = {mol_id.replace(self.exchange_key, ''): value for mol_id, value in changes.iteritems()}
         else:
             environment_change = {}
 
@@ -46,7 +44,6 @@ class LatticeCompartment(Compartment, Simulation):
             'motile_force': [0,0], # TODO -- get motile_force from compartment state
             'color': self.color,
             'environment_change': environment_change,
-            'transport_fluxes': {},  # TODO -- remove this
         })
 
         return values

--- a/lens/environment/lattice_compartment.py
+++ b/lens/environment/lattice_compartment.py
@@ -27,8 +27,7 @@ class LatticeCompartment(Compartment, Simulation):
         environment = self.states.get(self.environment)
         if environment:
             environment.assign_values(update['concentrations'])
-            environment.assign_values({key + self.exchange_key: 0
-                                       for key in self.environment_ids})  # reset delta counts to 0
+            environment.assign_values({key: 0 for key in self.exchange_ids})  # reset exchange
 
     def generate_inner_update(self):
         environment = self.states.get(self.environment)

--- a/lens/environment/lattice_compartment.py
+++ b/lens/environment/lattice_compartment.py
@@ -55,15 +55,13 @@ def generate_lattice_compartment(process, config):
         'process': process}
 
     # initialize states
-    defaults = process.default_state()
+    default_state = process.default_state()
+    default_updaters = process.default_updaters()
     states = {
-        role: State(defaults.get(role, {}))
-        for role in process.roles.keys()}
-
-    # TODO -- get updaters for all states. default is delta.
-    # updaters = {
-    #     process.get_updater(key) for key in process.roles.keys()
-    # }
+        role: State(
+            initial_state=default_state.get(role, {}),
+            updaters=default_updaters.get(role, {}))
+            for role in process.roles.keys()}
 
     # configure the states to the roles for each process
     topology = {
@@ -84,7 +82,7 @@ def generate_lattice_compartment(process, config):
         'environment': config.get('environment', 'external'),
         'compartment': config.get('compartment', 'internal'),
         'exchange_key': config['exchange_key'],
-        'environment_deltas': defaults['environment_deltas']}
+        'environment_deltas': default_state['environment_deltas']}
 
     options.update(config['compartment_options'])
 

--- a/lens/environment/lattice_compartment.py
+++ b/lens/environment/lattice_compartment.py
@@ -60,6 +60,11 @@ def generate_lattice_compartment(process, config):
         role: State(defaults.get(role, {}))
         for role in process.roles.keys()}
 
+    # TODO -- get updaters for all states. default is delta.
+    # updaters = {
+    #     process.get_updater(key) for key in process.roles.keys()
+    # }
+
     # configure the states to the roles for each process
     topology = {
         'process': {

--- a/lens/environment/look_up.py
+++ b/lens/environment/look_up.py
@@ -8,7 +8,6 @@ from lens.data.spreadsheets import JsonReader
 
 FLAT_DIR = os.path.join('lens', 'data', 'flat')
 MEDIA_IDS = ['minimal', 'minimal_minus_oxygen', 'minimal_plus_amino_acids']
-# CONC_STR = 'lookup_conc_'  # TODO -- load concentration lookup flat files.
 FLUX_STR = 'lookup_flux_'
 
 TSV_DIALECT = csv.excel_tab

--- a/lens/processes/CovertPalsson2002_metabolism.py
+++ b/lens/processes/CovertPalsson2002_metabolism.py
@@ -120,7 +120,7 @@ class Metabolism(Process):
 
     def default_emitter_keys(self):
         keys = {
-            'internal': ['mass', 'lacI'] + self.reaction_ids,
+            'internal': ['mass', 'lacI'] + self.transport_ids, #self.reaction_ids,
             'external': ['GLC', 'LAC', 'ACET']
         }
         return keys
@@ -215,6 +215,9 @@ class Metabolism(Process):
     def load_data(self):
         '''Load raw data from TSV files,
         save to data dictionary and then assign to class variables
+
+        TODO -- what is covert2002_exchange_fluxes doing besides providing external molecule ids?
+        TODO -- remove Growth reaction from covert2002_exchange_fluxes?
         '''
 
         data = {}
@@ -251,11 +254,9 @@ class Metabolism(Process):
         external_molecules = self.remove_e_key([mol_id for mol_id in all_molecules if self.e_key in mol_id])
         internal_molecules = [mol_id for mol_id in all_molecules if self.e_key not in mol_id]
 
-        # TODO -- what is covert2002_exchange_fluxes doing besides providing external molecule ids?
-        # TODO -- remove Growth reaction from covert2002_exchange_fluxes?
-
         # reaction ids for tracking fluxes
         self.reaction_ids = stoichiometry.keys()
+        self.transport_ids = transport_stoichiometry.keys()  # transport_ids are used by default_emitter
 
         # save external molecule ids, for use in update
         self.external_molecule_ids = external_molecules

--- a/lens/processes/CovertPalsson2002_metabolism.py
+++ b/lens/processes/CovertPalsson2002_metabolism.py
@@ -85,7 +85,6 @@ class Metabolism(Process):
     def default_state(self):
         '''
         returns dictionary with:
-            - environment_ids (list) -- unmodified external molecule ids for use to accumulate deltas in state
             - external (dict) -- external states with default initial values, will be overwritten by environment
             - internal (dict) -- internal states with default initial values
         '''

--- a/lens/processes/CovertPalsson2002_metabolism.py
+++ b/lens/processes/CovertPalsson2002_metabolism.py
@@ -125,6 +125,17 @@ class Metabolism(Process):
         }
         return keys
 
+    def default_updaters(self):
+        '''
+        define the updater type for each state in roles.
+        The default updater is to pass a delta'''
+
+        updater_types = {
+            'internal': {rxn_id: 'set' for rxn_id in self.reaction_ids},  # reactions set values directly
+            'external': {}}  # all external values use default 'delta' udpater
+
+        return updater_types
+
     def next_update(self, timestep, states):
 
         internal_state = states['internal']

--- a/lens/processes/CovertPalsson2002_metabolism.py
+++ b/lens/processes/CovertPalsson2002_metabolism.py
@@ -120,7 +120,7 @@ class Metabolism(Process):
 
     def default_emitter_keys(self):
         keys = {
-            'internal': ['mass', 'lacI',],  # self.reaction_ids,
+            'internal': ['mass', 'lacI'] + self.reaction_ids,
             'external': ['GLC', 'LAC', 'ACET']
         }
         return keys
@@ -132,7 +132,7 @@ class Metabolism(Process):
 
         updater_types = {
             'internal': {rxn_id: 'set' for rxn_id in self.reaction_ids},  # reactions set values directly
-            'external': {}}  # all external values use default 'delta' udpater
+            'external': {}}  # all external values use default 'delta' updater
 
         return updater_types
 
@@ -174,17 +174,11 @@ class Metabolism(Process):
         rxn_ids = self.fba.getReactionIDs()
         rxn_fluxes = self.fba.getReactionFluxes()
         rxn_dict = dict(zip(rxn_ids, rxn_fluxes))
-        rxn_delta = {rxn_id: new - internal_state[rxn_id] for rxn_id, new in rxn_dict.iteritems()}
 
-        # TODO -- update internal state mass
         update = {
-            'internal': merge_dicts(growth, rxn_delta),
-            'external': {mol_id + self.exchange_key: delta
-                for mol_id, delta in environment_deltas.iteritems()},
+            'internal': merge_dicts(growth, rxn_dict),
+            'external': {mol_id + self.exchange_key: delta for mol_id, delta in environment_deltas.iteritems()},
         }
-
-        import ipdb;
-        ipdb.set_trace()
 
         return update
 

--- a/lens/processes/CovertPalsson2002_regulation.py
+++ b/lens/processes/CovertPalsson2002_regulation.py
@@ -52,8 +52,6 @@ class Regulation(Process):
     def default_state(self):
         '''
         returns dictionary with:
-            - environment_deltas (list) -- external molecule ids with added self.exchange_key string, for use to accumulate deltas in state
-            - environment_ids (list) -- unmodified external molecule ids for use to accumulate deltas in state
             - external (dict) -- external states with default initial values, will be overwritten by environment
             - internal (dict) -- internal states with default initial values
         '''
@@ -62,16 +60,12 @@ class Regulation(Process):
         external_molecules = {key: True for key in self.external}
 
         return {
-            # 'environment_deltas': environment_deltas,
-            'environment_ids': self.external,
             'external': external_molecules,
             'internal': internal_molecules}
 
     def next_update(self, timestep, states):
         internal_state = states['internal']
         external_state = states['external']
-
-        # TODO -- add [e] back to external state?
 
         total_state = merge_dicts(internal_state, external_state)
         boolean_state = {mol_id: (value>0) for mol_id, value in total_state.iteritems()}

--- a/lens/processes/Endres2006_chemoreceptor.py
+++ b/lens/processes/Endres2006_chemoreceptor.py
@@ -50,8 +50,6 @@ class ReceptorCluster(Process):
     def default_state(self):
         '''
         returns dictionary with:
-            - environment_deltas (list) -- external molecule ids with added self.exchange_key string, for use to accumulate deltas in state
-            - environment_ids (list) -- unmodified external molecule ids for use to accumulate deltas in state
             - external (dict) -- external states with default initial values, will be overwritten by environment
             - internal (dict) -- internal states with default initial values
         '''
@@ -59,11 +57,8 @@ class ReceptorCluster(Process):
         internal = INITIAL_STATE
         internal.update({'volume': 1})
         external = {self.ligand_id: 0.0}
-        environment_ids = [self.ligand_id]
 
         return {
-            'environment_deltas': [],
-            'environment_ids': environment_ids,
             'external': external,
             'internal': internal}
 

--- a/lens/processes/Endres2006_chemoreceptor.py
+++ b/lens/processes/Endres2006_chemoreceptor.py
@@ -74,6 +74,17 @@ class ReceptorCluster(Process):
         }
         return keys
 
+    def default_updaters(self):
+        '''
+        define the updater type for each state in roles.
+        The default updater is to pass a delta'''
+
+        updater_types = {
+            'internal': {state_id: 'set' for state_id in ['chemoreceptor_P_on', 'n_methyl']},
+            'external': {}}
+
+        return updater_types
+
     def next_update(self, timestep, states):
         '''
         Monod-Wyman-Changeux model for mixed cluster activity
@@ -127,8 +138,8 @@ class ReceptorCluster(Process):
 
         update = {
             'internal': {
-                'chemoreceptor_P_on': P_on,  # TODO -- this expects a delta, not a new probability
-                'n_methyl': n_methyl,  # TODO -- this expects a delta, not a new probability
+                'chemoreceptor_P_on': P_on,
+                'n_methyl': n_methyl,
             }
         }
 

--- a/lens/processes/Kremling2007_transport.py
+++ b/lens/processes/Kremling2007_transport.py
@@ -304,6 +304,7 @@ class Transport(Process):
         }
 
         # internal update gets delta concentration
+        # TODO -- convert to counts.
         internal_update = {}
         for state_id in states['internal'].iterkeys():
             if state_id is 'volume':

--- a/lens/processes/Kremling2007_transport.py
+++ b/lens/processes/Kremling2007_transport.py
@@ -82,13 +82,11 @@ def merge_dicts(x, y):
 
 class Transport(Process):
     def __init__(self, initial_parameters={}):
-        self.exchange_key = initial_parameters['exchange_key']
         self.dt = 0.001  # timestep for ode integration (seconds)
 
         default_state = self.default_state()
         internal_state = default_state['internal']
         external_state = default_state['external']
-        self.environment_ids = default_state['environment_ids']
 
         roles = {
             'external': external_state.keys(),
@@ -101,8 +99,6 @@ class Transport(Process):
     def default_state(self):
         '''
         returns dictionary with:
-            - environment_deltas (list) -- external molecule ids with added self.exchange_key string, for use to accumulate deltas in state
-            - environment_ids (list) -- unmodified external molecule ids for use to accumulate deltas in state
             - external (dict) -- external states with default initial values, will be overwritten by environment
             - internal (dict) -- internal states with default initial values
         '''
@@ -136,18 +132,11 @@ class Transport(Process):
                 'XP': 0.01,  # [fraction phosphorylation]
             }
 
-        environment_ids = external.keys()
-        external_changes = [key + self.exchange_key for key in environment_ids]
-
-        # declare the states
-        external_molecules = merge_dicts(external, {key: 0 for key in external_changes})
-        internal_molecules = merge_dicts(internal, {'volume': 1}) # fL TODO -- get volume with deriver?
+        self.environment_ids = external.keys()
 
         return {
-            'environment_deltas': external_changes,
-            'environment_ids': environment_ids,
-            'external': external_molecules,
-            'internal': internal_molecules}
+            'external': external,
+            'internal': merge_dicts(internal, {'volume': 1})}  #TODO -- get volume with deriver?
 
     def default_emitter_keys(self):
         keys = {
@@ -155,6 +144,17 @@ class Transport(Process):
             'external': ['G6P', 'GLC', 'LAC']
         }
         return keys
+
+    def default_updaters(self):
+        '''
+        define the updater type for each state in roles.
+        The default updater is to pass a delta'''
+
+        updater_types = {
+            'internal': {},  # reactions set values directly
+            'external': {mol_id: 'accumulate' for mol_id in self.environment_ids}}  # all external values use default 'delta' udpater
+
+        return updater_types
 
     def next_update(self, timestep, states):
 
@@ -312,5 +312,5 @@ class Transport(Process):
             internal_update[state_id] = delta_concs[state_id]
 
         return {
-            'external': {mol_id + self.exchange_key: delta for mol_id, delta in environment_delta_counts.iteritems()},
+            'external': environment_delta_counts,
             'internal': internal_update}

--- a/lens/processes/transport_lookup.py
+++ b/lens/processes/transport_lookup.py
@@ -51,9 +51,7 @@ external_molecule_ids_p = [mol_id + '[p]' for mol_id in external_molecule_ids]
 
 COUNTS_UNITS = units.mmol
 VOLUME_UNITS = units.L
-# MASS_UNITS = units.g
 TIME_UNITS = units.s
-# CONC_UNITS = COUNTS_UNITS / VOLUME_UNITS
 FLUX_UNITS = COUNTS_UNITS / VOLUME_UNITS / TIME_UNITS
 
 
@@ -146,15 +144,11 @@ class TransportLookup(Process):
     # TODO (Eran) -- make this a util
     def flux_to_counts(self, fluxes, conversion):
 
-        rxn_counts = {
-            reaction_id: int(conversion * flux)
-            for reaction_id, flux in fluxes.iteritems()}
+        rxn_counts = {reaction_id: int(conversion * flux) for reaction_id, flux in fluxes.iteritems()}
         delta_counts = {}
         for reaction_id, rxn_count in rxn_counts.iteritems():
             stoichiometry = self.all_transport_reactions[reaction_id]['stoichiometry']
-            substrate_counts = {
-                substrate_id: coeff * rxn_count
-                for substrate_id, coeff in stoichiometry.iteritems()}
+            substrate_counts = {substrate_id: coeff * rxn_count for substrate_id, coeff in stoichiometry.iteritems()}
             # add to delta_counts
             for substrate, delta in substrate_counts.iteritems():
                 if substrate in delta_counts:

--- a/lens/utils/rate_law_utilities.py
+++ b/lens/utils/rate_law_utilities.py
@@ -37,10 +37,10 @@ import lens.utils.kinetic_rate_laws as rate_laws
 
 TSV_DIALECT = csv.excel_tab
 
-REACTIONS_FILE = os.path.join("lens", "data", "flat", "reactions.tsv")
-PROTEINS_FILE = os.path.join("lens", "data", "flat", "proteins.tsv")
-COMPLEXATION_FILE = os.path.join("lens", "data", "flat", "complexationReactions.tsv")
-KINETIC_PARAMETERS_PATH = os.path.join("lens", 'data', 'kinetic_rate_laws', 'parameters')
+REACTIONS_FILE = os.path.join("lens", "data", "flat", "wcEcoli_reactions.tsv")
+PROTEINS_FILE = os.path.join("lens", "data", "flat", "wcEcoli_proteins.tsv")
+COMPLEXATION_FILE = os.path.join("lens", "data", "flat", "wcEcoli_complexationReactions.tsv")
+KINETIC_PARAMETERS_PATH = os.path.join("lens", 'data', 'json_files')
 OUTPUT_DIR = os.path.join('out', 'kinetic_rate_laws')
 
 


### PR DESCRIPTION
updaters from #41 are here being applied in the metabolism process, introducing both ```set``` updaters that directly set the reaction flux values rather than passing deltas, and ```accumulate``` updaters that replace the previous method of tracking delta counts with additional  ```__exchange``` key in the state. ```accumulate``` takes the (key, value) passed in update, and adds the value to a key+exchange_key. This is used to pass accumulated delta counts in generate_inner_update, and upon generate_outer update all key+exchange_key are reset to a value of 0.