### PR TITLE
Chemotaxis composite

### DIFF
--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -231,26 +231,29 @@ def merge_default_states(processes):
     initial_state = {}
     for process_id, process in processes.iteritems():
         default = process.default_state()
-        initial_state = dict_merge(initial_state, default)
+        initial_state = dict_merge(dict(initial_state), default)
     return initial_state
 
 def merge_default_updaters(processes):
     updaters = {}
     for process_id, process in processes.iteritems():
         process_updaters = process.default_updaters()
-        updaters = dict_merge(updaters, process_updaters)
+        updaters = dict_merge(dict(updaters), process_updaters)
     return updaters
 
 def dict_merge(dct, merge_dct):
-    ''' Recursive dict merge '''
-    new_dict = dct.copy()
+    '''
+    Recursive dict merge
+    This mutates dct - the contents of merge_dct are added to dct (which is also returned).
+    If you want to keep dct you could call it like dict_merge(dict(dct), merge_dct)'''
     for k, v in merge_dct.iteritems():
-        if (k in new_dict and isinstance(new_dict[k], dict)
+        if (k in dct and isinstance(dct[k], dict)
                 and isinstance(merge_dct[k], collections.Mapping)):
-            dict_merge(new_dict[k], merge_dct[k])
+            dict_merge(dct[k], merge_dct[k])
         else:
-            new_dict[k] = merge_dct[k]
-    return new_dict
+            dct[k] = merge_dct[k]
+    return dct
+
 
 class Compartment(object):
     ''' Track a set of processes and states and the connections between them. '''

--- a/lens/analysis/analyze_lattice.py
+++ b/lens/analysis/analyze_lattice.py
@@ -23,6 +23,8 @@ def location_trace(exp_data, history_data, experiment_id, output_dir='out'):
         y_coord = locations_array[:, 1]
         angle = locations_array[:, 2]
 
+        # mark starting point
+        plt.plot(x_coord[0], y_coord[0], 'r*')
         for i in range(len(locations)):
             plt.plot(x_coord[i:i + 2], y_coord[i:i + 2], 'b-')
 

--- a/lens/composites/Chemotaxis.py
+++ b/lens/composites/Chemotaxis.py
@@ -12,7 +12,7 @@ from lens.processes.derive_volume import DeriveVolume
 
 exchange_key = '__exchange'  # TODO -- this is declared in multiple locations
 
-def initialize_vladimirov2008(config):
+def initialize_chemotaxis(config):
     config.update({
         'emitter': {
             'type': 'database',

--- a/lens/composites/Covert2008.py
+++ b/lens/composites/Covert2008.py
@@ -58,7 +58,7 @@ def initialize_covert2008(config):
 
     states = {
         compartment_roles[role]: State(
-            initial_state=dict_merge(default_states.get(role, {}), initial_exchanges.get(role, {})),
+            initial_state=dict_merge(dict(default_states.get(role, {})), initial_exchanges.get(role, {})),
             updaters=default_updaters.get(role, {}))
             for role in default_states.keys()}
 

--- a/lens/composites/Vladimirov2008.py
+++ b/lens/composites/Vladimirov2008.py
@@ -24,11 +24,12 @@ def initialize_vladimirov2008(config):
     # declare the processes
     receptor = ReceptorCluster(config)
     motor = MotorActivity(config)
-    deriver = DeriveVolume(config)
+    # deriver = DeriveVolume(config)
     processes = {
         'receptor': receptor,
         'motor': motor,
-        'deriver': deriver}
+        # 'deriver': deriver
+    }
 
     # initialize the states
     default_states = merge_default_states(processes)
@@ -55,9 +56,10 @@ def initialize_vladimirov2008(config):
 
     states = {
         compartment_roles[role]: State(
-            initial_state=dict_merge(default_states.get(role, {}), initial_exchanges.get(role, {})),
+            initial_state=dict_merge(dict(default_states.get(role, {})), initial_exchanges.get(role, {})),
             updaters=default_updaters.get(role, {}))
         for role in default_states.keys()}
+
     # configure the states to the roles for each process
     topology = {
         'receptor': {
@@ -66,8 +68,8 @@ def initialize_vladimirov2008(config):
         'motor': {
             'external': 'environment',
             'internal': 'cell'},
-        'deriver': {
-            'internal': 'cell'},
+        # 'deriver': {
+        #     'internal': 'cell'},
         }
 
     # configure emitter

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -254,7 +254,7 @@ def initialize_measp(agent_config):
              'MeAsp': 0.1 * conc_units}
 
     media_id = make_media.add_media(media, media_id)
-    timeline_str = '0 {}, 1000 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
+    timeline_str = '0 {}, 3600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
     timeline = make_media.make_timeline(timeline_str)
 
     boot_config = {
@@ -266,17 +266,17 @@ def initialize_measp(agent_config):
             'seed': True,
             'molecules': {
                 'GLC': {
-                    'center': [0.5, 1.0],
+                    'center': [0.5, 0.5],
                     'deviation': 30.0},
                 'MeAsp': {
-                    'center': [0.5, 1.0],
+                    'center': [0.5, 0.5],
                     'deviation': 30.0}
             }},
         'diffusion': 0.0,
         'translation_jitter': 0.5,
         'rotation_jitter': 0.005,
-        'edge_length': 100.0,
-        'patches_per_edge': 20}
+        'edge_length': 200.0,
+        'patches_per_edge': 40}
     boot_config.update(agent_config)
 
     return boot_config
@@ -284,11 +284,11 @@ def initialize_measp(agent_config):
 
 def initialize_measp_timeline(agent_config):
     media_id = 'MeAsp timeline'
-    # Endres and Wingreen (2006) use + 100 uM = 0.1 mmol for attractant
+    # Endres and Wingreen (2006) use + 100 uM = 0.1 mmol for attractant. 0.2 b/c of dilution.
     timeline_str = '0 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
-                   '200 GLC 20.0 mmol 1 L + MeAsp 0.1 mmol 1 L, ' \
+                   '200 GLC 20.0 mmol 1 L + MeAsp 0.2 mmol 1 L, ' \
                    '600 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
-                   '1000 GLC 20.0 mmol 1 L + MeAsp 0.01 mmol 1 L, ' \
+                   '1000 GLC 20.0 mmol 1 L + MeAsp 0.02 mmol 1 L, ' \
                    '1400 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
                    '1600 end'
 
@@ -298,18 +298,7 @@ def initialize_measp_timeline(agent_config):
         'media_object': make_media,
         'timeline': timeline,
         'run_for': 1.0,
-        # 'concentrations': media,
         'static_concentrations': True,
-        'gradient': {
-            'seed': True,
-            'molecules': {
-                'GLC': {
-                    'center': [0.5, 1.0],
-                    'deviation': 50.0},
-                'MeAsp': {
-                    'center': [0.25, 0.25],
-                    'deviation': 30.0}
-            }},
         'diffusion': 0.0,
         'translation_jitter': 0.5,
         'rotation_jitter': 0.005,

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -43,7 +43,7 @@ from lens.processes.Vladimirov2008_motor import MotorActivity
 # composites
 from lens.composites.Covert2008 import initialize_covert2008
 from lens.composites.growth_division import initialize_growth_division
-from lens.composites.Vladimirov2008 import initialize_vladimirov2008
+from lens.composites.Chemotaxis import initialize_chemotaxis
 
 
 DEFAULT_COLOR = [0.6, 0.4, 0.3]
@@ -254,7 +254,7 @@ def initialize_measp(agent_config):
              'MeAsp': 0.1 * conc_units}
 
     media_id = make_media.add_media(media, media_id)
-    timeline_str = '0 {}, 3600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
+    timeline_str = '0 {}, 1000 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
     timeline = make_media.make_timeline(timeline_str)
 
     boot_config = {
@@ -284,12 +284,13 @@ def initialize_measp(agent_config):
 
 def initialize_measp_timeline(agent_config):
     media_id = 'MeAsp timeline'
+    # Endres and Wingreen (2006) use + 100 uM = 0.1 mmol for attractant
     timeline_str = '0 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
-                   '100 GLC 20.0 mmol 1 L + MeAsp 0.01 mmol 1 L, ' \
-                   '300 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
-                   '500 GLC 20.0 mmol 1 L + MeAsp 0.1 mmol 1 L, ' \
-                   '700 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
-                   '1000 end'
+                   '200 GLC 20.0 mmol 1 L + MeAsp 0.1 mmol 1 L, ' \
+                   '600 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
+                   '1000 GLC 20.0 mmol 1 L + MeAsp 0.01 mmol 1 L, ' \
+                   '1400 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
+                   '1600 end'
 
     make_media = Media()
     timeline = make_media.make_timeline(timeline_str)
@@ -345,7 +346,7 @@ class BootEnvironment(BootAgent):
             # composite compartments
             'growth_division': wrap_boot(initialize_growth_division, {'volume': 1.0}),
             'covert2008': wrap_boot(initialize_covert2008, {'volume': 1.0}),
-            'vladimirov2008': wrap_boot(initialize_vladimirov2008, {'volume': 1.0})
+            'chemotaxis': wrap_boot(initialize_chemotaxis, {'volume': 1.0})
             }
 
 def run():

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -260,7 +260,7 @@ def initialize_measp(agent_config):
     boot_config = {
         'timeline': timeline,
         'media_object': make_media,
-        'run_for': 2.0,
+        'run_for': 1.0,
         'static_concentrations': True,
         'gradient': {
             'seed': True,
@@ -276,7 +276,7 @@ def initialize_measp(agent_config):
         'translation_jitter': 0.5,
         'rotation_jitter': 0.005,
         'edge_length': 100.0,
-        'patches_per_edge': 50}
+        'patches_per_edge': 20}
     boot_config.update(agent_config)
 
     return boot_config
@@ -296,6 +296,7 @@ def initialize_measp_timeline(agent_config):
     boot_config = {
         'media_object': make_media,
         'timeline': timeline,
+        'run_for': 1.0,
         # 'concentrations': media,
         'static_concentrations': True,
         'gradient': {

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -182,25 +182,22 @@ def initialize_custom_small(agent_config):
     # set up media
     media_id = 'custom'
     make_media = Media()
-    COUNTS_UNITS = units.mmol
-    VOLUME_UNITS = units.L
-    CONC_UNITS = COUNTS_UNITS / VOLUME_UNITS
-
+    conc_units = units.mmol / units.L
     custom_media = {
-        "ACET": 0.0 * CONC_UNITS,
-        "CO+2": 100.0 * CONC_UNITS,
-        "ETOH": 0.0 * CONC_UNITS,
-        "FORMATE": 0.0 * CONC_UNITS,
-        "GLYCEROL": 0.0 * CONC_UNITS,
-        "LAC": 0.0 * CONC_UNITS,
-        "LCTS": 3.4034 * CONC_UNITS,
-        "OXYGEN-MOLECULE": 100.0 * CONC_UNITS,
-        "PI": 100.0 * CONC_UNITS,
-        "PYR": 0.0 * CONC_UNITS,
-        "RIB": 0.0 * CONC_UNITS,
-        "SUC": 0.0 * CONC_UNITS,
-        "G6P": 1.3451 * CONC_UNITS,
-        "GLC": 12.2087 * CONC_UNITS}
+        "ACET": 0.0 * conc_units,
+        "CO+2": 100.0 * conc_units,
+        "ETOH": 0.0 * conc_units,
+        "FORMATE": 0.0 * conc_units,
+        "GLYCEROL": 0.0 * conc_units,
+        "LAC": 0.0 * conc_units,
+        "LCTS": 3.4034 * conc_units,
+        "OXYGEN-MOLECULE": 100.0 * conc_units,
+        "PI": 100.0 * conc_units,
+        "PYR": 0.0 * conc_units,
+        "RIB": 0.0 * conc_units,
+        "SUC": 0.0 * conc_units,
+        "G6P": 1.3451 * conc_units,
+        "GLC": 12.2087 * conc_units}
     media_id = make_media.add_media(custom_media, media_id)
 
     timeline_str = '0 {}, 3600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
@@ -249,6 +246,43 @@ def initialize_glc_lct(agent_config):
     return boot_config
 
 def initialize_measp(agent_config):
+
+    conc_units = units.mmol / units.L
+    make_media = Media()
+    media_id = 'MeAsp_media'
+    media = {'GLC': 20.0 * conc_units,
+             'MeAsp': 0.1 * conc_units}
+
+    media_id = make_media.add_media(media, media_id)
+    timeline_str = '0 {}, 3600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
+    timeline = make_media.make_timeline(timeline_str)
+
+    boot_config = {
+        'timeline': timeline,
+        'media_object': make_media,
+        'run_for': 2.0,
+        'static_concentrations': True,
+        'gradient': {
+            'seed': True,
+            'molecules': {
+                'GLC': {
+                    'center': [0.5, 1.0],
+                    'deviation': 30.0},
+                'MeAsp': {
+                    'center': [0.5, 1.0],
+                    'deviation': 30.0}
+            }},
+        'diffusion': 0.0,
+        'translation_jitter': 0.5,
+        'rotation_jitter': 0.005,
+        'edge_length': 100.0,
+        'patches_per_edge': 50}
+    boot_config.update(agent_config)
+
+    return boot_config
+
+
+def initialize_measp_timeline(agent_config):
     media_id = 'MeAsp timeline'
     timeline_str = '0 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
                    '100 GLC 20.0 mmol 1 L + MeAsp 0.01 mmol 1 L, ' \
@@ -296,6 +330,7 @@ class BootEnvironment(BootAgent):
             'sugar2': wrap_boot_environment(initialize_glc_lct),
             'custom': wrap_boot_environment(initialize_custom_small),
             'measp': wrap_boot_environment(initialize_measp),
+            'measp_timeline': wrap_boot_environment(initialize_measp_timeline),
 
             # single process compartments
             'lookup': wrap_boot(wrap_initialize(TransportLookup), {'volume': 1.0}),
@@ -309,7 +344,7 @@ class BootEnvironment(BootAgent):
             # composite compartments
             'growth_division': wrap_boot(initialize_growth_division, {'volume': 1.0}),
             'covert2008': wrap_boot(initialize_covert2008, {'volume': 1.0}),
-            'vladimirov': wrap_boot(initialize_vladimirov2008, {'volume': 1.0})
+            'vladimirov2008': wrap_boot(initialize_vladimirov2008, {'volume': 1.0})
             }
 
 def run():

--- a/lens/environment/lattice.py
+++ b/lens/environment/lattice.py
@@ -77,7 +77,8 @@ class EnvironmentSpatialLattice(EnvironmentSimulation):
         self.shutdown = False
         if self.timeline:
             self._times = [t[0] for t in self.timeline]
-            media = self.make_media.get_saved_media(self.timeline[0][1])
+            self.media_id = self.timeline[0][1]
+            media = self.make_media.get_saved_media(self.media_id)
             self._molecule_ids = media.keys()
             self.concentrations = media.values()
         else:

--- a/lens/environment/lattice_compartment.py
+++ b/lens/environment/lattice_compartment.py
@@ -75,7 +75,7 @@ def generate_lattice_compartment(process, config):
 
     states = {
         role: State(
-            initial_state=dict_merge(default_state.get(role, {}), initial_exchanges.get(role, {})),
+            initial_state=dict_merge(dict(default_state.get(role, {})), initial_exchanges.get(role, {})),
             updaters=default_updaters.get(role, {}))
             for role in process.roles.keys()}
 

--- a/lens/processes/CovertPalsson2002_metabolism.py
+++ b/lens/processes/CovertPalsson2002_metabolism.py
@@ -102,7 +102,7 @@ class Metabolism(Process):
 
         # add reaction fluxes to internal state
         rxns = {rxn_id: 0.0 for rxn_id in self.reaction_ids}
-        internal_state = dict_merge(internal, rxns)
+        internal_state = dict_merge(dict(internal), rxns)
 
         return {
             'external': external,
@@ -124,7 +124,7 @@ class Metabolism(Process):
         mass_updater = {'mass': 'set'}
 
         updater_types = {
-            'internal': dict_merge(reaction_updaters, mass_updater),
+            'internal': dict_merge(dict(reaction_updaters), mass_updater),
             'external': {mol_id: 'accumulate' for mol_id in self.external_molecule_ids}}  # all external values use default 'delta' udpater
 
         return updater_types
@@ -145,7 +145,7 @@ class Metabolism(Process):
         volume = mass.to('g') / self.density # TODO -- volume deriver can do this if composed with process
 
         # get the regulatory state of the reactions TODO -- are there reversible regulated reactions?
-        total_state = dict_merge(internal_state, external_state)
+        total_state = dict_merge(dict(internal_state), external_state)
         boolean_state = {mol_id: (value>0) for mol_id, value in total_state.iteritems()}
         regulatory_state = {mol_id: regulatory_logic(boolean_state)
                             for mol_id, regulatory_logic in self.regulation_logic.iteritems()}
@@ -190,7 +190,7 @@ class Metabolism(Process):
         rxn_dict = dict(zip(rxn_ids, rxn_fluxes))
 
         update = {
-            'internal': dict_merge(new_mass, rxn_dict),
+            'internal': dict_merge(dict(new_mass), rxn_dict),
             'external': environment_deltas}
 
         return update

--- a/lens/processes/Endres2006_chemoreceptor.py
+++ b/lens/processes/Endres2006_chemoreceptor.py
@@ -3,18 +3,20 @@ from __future__ import absolute_import, division, print_function
 import math
 
 from lens.actor.process import Process
+from lens.utils.units import units
 
 
 LIGAND_ID = 'MeAsp'
 
 INITIAL_STATE = {
-    'n_methyl': 3.0,  # initial number of methyl groups on receptor cluster (0 to 8)
-    'chemoreceptor_activity': 1 / 3,  # initial probability of receptor cluster being on
+    'n_methyl': 2.0,  # initial number of methyl groups on receptor cluster (0 to 8)
+    'chemoreceptor_activity': 1./3.,  # initial probability of receptor cluster being on
     'CheR': 0.00016,  # (mM) wild type concentration. 0.16 uM = 0.00016 mM
     'CheB': 0.00028,  # (mM) wild type concentration. 0.28 uM = 0.00028 mM. [CheR]:[CheB]=0.16:0.28
     'CheB_P': 0.0,  # phosphorylated CheB
 }
 
+# Parameters from Endres and Wingreen 2006. See paper for serine binding, NiCl2 binding rates.
 DEFAULT_PARAMETERS = {
     'n_Tar': 6,  # number of Tar receptors in a cluster
     'n_Tsr': 12,  # number of Tsr receptors in a cluster
@@ -30,9 +32,8 @@ DEFAULT_PARAMETERS = {
     # k_CheB = 0.0364  # effective catalytic rate of CheB
     'k_meth': 0.0625,  # Catalytic rate of methylation
     'k_demeth': 0.0714,  # Catalytic rate of demethylation
-    'adaptRate': 1500,  # adaptation rate relative to wild-type. cell-to-cell variation cause by variability in [CheR, CheB]
+    'adaptRate': 2,  #1000, # adaptation rate relative to wild-type. cell-to-cell variation cause by variability in [CheR, CheB]
 }
-
 
 
 class ReceptorCluster(Process):
@@ -87,20 +88,34 @@ class ReceptorCluster(Process):
         Monod-Wyman-Changeux model for mixed cluster activity from:
             Endres & Wingreen. (2006). Precise adaptation in bacterial chemotaxis through "assistance neighborhoods"
         '''
-
+        # states
         n_methyl = states['internal']['n_methyl']
         P_on = states['internal']['chemoreceptor_activity']
-        CheR = states['internal']['CheR']
-        CheB = states['internal']['CheB']
-        ligand_conc = states['external'][self.ligand_id]
+        CheR = states['internal']['CheR'] * (units.mmol / units.L)
+        CheB = states['internal']['CheB'] * (units.mmol / units.L)
+        ligand_conc = states['external'][self.ligand_id]   # mmol/L
+
+        # convert to umol / L
+        CheR = CheR.to('umol/L').magnitude
+        CheB = CheB.to('umol/L').magnitude
+
+        # parameters
+        n_Tar = self.parameters['n_Tar']
+        n_Tsr = self.parameters['n_Tsr']
+        K_Tar_off = self.parameters['K_Tar_off']
+        K_Tar_on = self.parameters['K_Tar_on']
+        K_Tsr_off = self.parameters['K_Tsr_off']
+        K_Tsr_on = self.parameters['K_Tsr_on']
+        adaptRate = self.parameters['adaptRate']
+        k_meth = self.parameters['k_meth']
+        k_demeth = self.parameters['k_demeth']
 
         if n_methyl < 0:
             n_methyl = 0
         elif n_methyl > 8:
             n_methyl = 8
         else:
-            d_methyl = self.parameters['adaptRate'] * (self.parameters['k_meth'] * \
-                            CheR * (1.0 - P_on) - self.parameters['k_demeth'] * CheB * P_on) * timestep
+            d_methyl = adaptRate * (k_meth * CheR * (1.0 - P_on) - k_demeth * CheB * P_on) * timestep
             n_methyl += d_methyl
 
         # get free-energy offsets from methylation
@@ -121,13 +136,9 @@ class ReceptorCluster(Process):
             offset_energy = -3.0
 
         # free energy of the receptors.
-        # TODO -- generalize to multiple types of ligands. See eqn 9 in supporting info for Endres & Wingreen 2006
-        Tar_free_energy = self.parameters['n_Tar'] * \
-                          (offset_energy + math.log((1+ligand_conc/self.parameters['K_Tar_off'])/
-                          (1+ligand_conc/self.parameters['K_Tar_on'])))
-        Tsr_free_energy = self.parameters['n_Tsr'] * \
-                          (offset_energy + math.log((1+ligand_conc/self.parameters['K_Tsr_off'])/
-                          (1+ligand_conc/self.parameters['K_Tsr_on'])))
+        # TODO -- generalize to other ligands (repellents). See Endres & Wingreen 2006 eqn 9 in supporting info
+        Tar_free_energy = n_Tar * (offset_energy + math.log((1+ligand_conc/K_Tar_off) / (1+ligand_conc/K_Tar_on)))
+        Tsr_free_energy = n_Tsr * (offset_energy + math.log((1+ligand_conc/K_Tsr_off) / (1+ligand_conc/K_Tsr_on)))
 
         # free energy of receptor clusters
         cluster_free_energy = Tar_free_energy + Tsr_free_energy  #  free energy of the cluster
@@ -139,3 +150,101 @@ class ReceptorCluster(Process):
                 'n_methyl': n_methyl,
             }}
         return update
+
+
+def test_receptor():
+    # TODO -- add asserts for test
+    # define timeline with (time (s), ligand concentration (mmol/L))
+    timeline = [
+        (0, 0.0),
+        (200, 0.01),
+        (600, 0.0),
+        (1000, 0.1),
+        (1400, 0.0),
+        (1800, 1.0),
+        (2200, 0.0),
+        (2600, 10.0),
+        (3000, 0.0),
+    ]
+    time = 0
+    timestep = 1
+
+    # initialize process
+    receptor = ReceptorCluster()
+    state = receptor.default_state()
+    ligand_id = receptor.ligand_id
+
+    # run simulation
+    ligand_vec = []
+    receptor_activity_vec = []
+    n_methyl_vec = []
+    while time < timeline[-1][0]:
+        time += timestep
+        for (t, conc) in timeline:
+            if time < t:
+                pass
+            else:
+                ligand_conc = conc
+                state['external'][ligand_id] = ligand_conc
+                continue
+
+        # run step
+        update = receptor.next_update(timestep, state)
+        P_on = update['internal']['chemoreceptor_activity']
+        n_methyl = update['internal']['n_methyl']
+
+        # update state
+        state['internal']['chemoreceptor_activity'] = P_on
+        state['internal']['n_methyl'] = n_methyl
+
+        # save state
+        ligand_vec.append(ligand_conc)
+        receptor_activity_vec.append(P_on)
+        n_methyl_vec.append(n_methyl)
+
+    return {
+        'ligand_vec': ligand_vec,
+        'receptor_activity_vec': receptor_activity_vec,
+        'n_methyl_vec': n_methyl_vec}
+
+def plot_output(output):
+    import os
+    import matplotlib
+    matplotlib.use('TkAgg')
+    import matplotlib.pyplot as plt
+
+    ligand_vec = output['ligand_vec']
+    receptor_activity_vec = output['receptor_activity_vec']
+    n_methyl_vec = output['n_methyl_vec']
+
+    # plot results
+    cols = 1
+    rows = 3
+    plt.figure(figsize=(6 * cols, 1 * rows))
+
+    ax1 = plt.subplot(rows, cols, 1)
+    ax2 = plt.subplot(rows, cols, 2)
+    ax3 = plt.subplot(rows, cols, 3)
+
+    ax1.plot(ligand_vec, 'b')
+    ax2.plot(receptor_activity_vec, 'b')
+    ax3.plot(n_methyl_vec, 'b')
+
+    ax1.set_xticklabels([])
+    ax1.set_ylabel("ligand \n log(mM) ", fontsize=10)
+    ax1.set_yscale('log')
+    ax2.set_xticklabels([])
+    ax2.set_ylabel("activity \n P(on)", fontsize=10)
+    ax3.set_xlabel("time (s)", fontsize=12)
+    ax3.set_ylabel("average \n methylation", fontsize=10)
+
+    OUTPUT_PLOT = os.path.join(
+        'out', 'Endres2006_chemoreceptor_test'
+    )
+    plt.subplots_adjust(wspace=0.7, hspace=0.1)
+    plt.savefig(OUTPUT_PLOT + '.png', bbox_inches='tight')
+
+
+if __name__ == '__main__':
+    output = test_receptor()
+    plot_output(output)

--- a/lens/processes/Vladimirov2008_motor.py
+++ b/lens/processes/Vladimirov2008_motor.py
@@ -12,10 +12,10 @@ TUMBLE_JITTER = 0.5  # (radians)
 DEFAULT_PARAMETERS = {
     'k_A': 5.0,  #
     'k_y': 100.0,  # 1/uM/s
-    'k_z': 30.0,  # / self.CheZ,
+    'k_z': 30.0,  # / CheZ,
     'gamma_Y': 0.1,
     'k_s': 0.45,  # scaling coefficient
-    'adaptPrecision': 0.3,  # set to 1.0 for perfect adaptation
+    'adaptPrecision': 3,
     # motor
     'mb_0': 0.65,
     'n_motors': 5,
@@ -27,7 +27,8 @@ INITIAL_STATE = {
     # response regulator proteins
     'CheY_tot': 0.0097,  # (mM) 9.7 uM = 0.0097 mM
     'CheY_P': 0.0,
-    'CheZ': 0.0,  # phosphatase
+    'CheZ': 0.1,  # phosphatase 100 uM = 0.1 mM (from RapidCell1.4.2)
+    'CheA': 0.1,  # 100 uM = 0.1 mM (from RapidCell1.4.2)
     # sensor activity
     'chemoreceptor_activity': 1/3,
     # motor activity
@@ -41,14 +42,15 @@ class MotorActivity(Process):
     Model of motor activity from:
         Vladimirov, N., Lovdok, L., Lebiedz, D., & Sourjik, V. (2008).
         Dependence of bacterial chemotaxis on gradient shape and adaptation rate.
-        PLoS computational biology.
     '''
     def __init__(self, initial_parameters={}):
 
         roles = {
             'internal': ['chemoreceptor_activity',
+                         'CheA',
                          'CheZ',
                          'CheY_tot',
+                         'CheY_P',
                          'motile_force',
                          'motile_torque',
                          'motor_state'],
@@ -72,7 +74,7 @@ class MotorActivity(Process):
 
     def default_emitter_keys(self):
         keys = {
-            'internal': ['motile_force', 'motile_torque', 'motor_state'],
+            'internal': ['motile_force', 'motile_torque', 'motor_state', 'CheA', 'CheY_P'],
             'external': [],
         }
         return keys
@@ -81,7 +83,7 @@ class MotorActivity(Process):
         '''
         define the updater type for each state in roles.
         The default updater is to pass a delta'''
-        set_states = ['motile_force', 'motile_torque', 'motor_state']
+        set_states = ['motile_force', 'motile_torque', 'motor_state', 'CheA', 'CheY_P']
         updater_types = {
             'internal': {state_id: 'set' for state_id in set_states},
             'external': {}}
@@ -96,6 +98,10 @@ class MotorActivity(Process):
         Motor switching model from:
             Scharf, B. E., Fahrner, K. A., Turner, L., and Berg, H. C. (1998).
             Control of direction of flagellar rotation in bacterial chemotaxis. PNAS.
+
+        An increase of attractant inhibits CheA activity (chemoreceptor_activity),
+        but subsequent methylation returns CheA activity to its original level.
+        TODO -- add CheB phosphorylation
         '''
 
         internal = states['internal']
@@ -104,30 +110,38 @@ class MotorActivity(Process):
         motor_state = internal['motor_state']
         CheZ = internal['CheZ']
         CheY_tot = internal['CheY_tot']
+        CheA_tot = internal['CheA']
 
-        # print('receptor activity: {}'.format(P_on))
+        # parameters
+        adaptPrecision = self.parameters['adaptPrecision']
+        k_A = self.parameters['k_A']
+        k_y = self.parameters['k_y']
+        k_s = self.parameters['k_s']
+        k_z = self.parameters['k_z']
+        gamma_Y  =self.parameters['gamma_Y']
+        mb_0 = self.parameters['mb_0']
+        cw_to_ccw = self.parameters['cw_to_ccw']
 
+        ## Kinase activity
+        CheA_P = CheA_tot * P_on * k_A / (P_on * k_A + k_y * CheY_tot)  # amount of phosphorylated CheA
 
-        ## CheY phosphorylation, scaled to 1.0 at rest
-        # self.CheA_P = self.CheA_tot * self.P_on * k_A / (self.P_on * k_A + k_y * self.CheY_tot)  # amount of phosphorylated CheA
-        # scaling = 19.3610  # scales CheY_P linearly so that CheY_P=1 at rest (P_on=1/3)
-        # self.CheY_P = adaptPrecision * scaling * self.CheY_tot * k_y * self.CheA_P / (k_y * self.CheA_P + k_z * self.CheZ + gamma_Y)
-        CheY_P = self.parameters['adaptPrecision'] * 3 * self.parameters['k_y'] * CheY_tot * P_on * self.parameters['k_s'] / \
-                 (self.parameters['k_y'] * self.parameters['k_s'] * P_on + self.parameters['k_z'] * CheZ + self.parameters['gamma_Y'])
+        # relative steady-state concentration of phosphorylated CheY.
+        # CheA_P assumed to be equal to the activity of the receptor complex (P_on)
+        # CheY_P = adaptPrecision * k_y * k_s * P_on / (k_y * k_s * P_on + k_z * CheZ + gamma_Y)
+        # scaling = 1.0688 # 19.3610  # scales CheY_P linearly so that CheY_P=1 at rest (P_on=1/3)
+        CheY_P = adaptPrecision * k_y * k_s * CheA_P / (k_y * k_s * CheA_P + k_z * CheZ + gamma_Y)
 
         # CheB phosphorylation
-        # TODO!
-        # CheB =
-
+        # CheB_P = CheB_tot * P_on / (P_on + self.parameters['k_0.5'])
 
         ## Motor switching
         # CCW corresponds to run. CW corresponds to tumble
-        ccw_motor_bias = self.parameters['mb_0'] / (CheY_P/CheY_tot * (1 - self.parameters['mb_0']) + self.parameters['mb_0'])
-        cww_to_cw = self.parameters['cw_to_ccw'] * (1 / ccw_motor_bias - 1)
+        ccw_motor_bias = mb_0 / (CheY_P/CheY_tot * (1 - mb_0) + mb_0)
+        ccw_to_cw = cw_to_ccw * (1 / ccw_motor_bias - 1)
 
         if motor_state == 0:  # 0 for run
             # switch to tumble?
-            prob_switch = cww_to_cw * timestep
+            prob_switch = ccw_to_cw * timestep
             if prob_switch <= np.random.random(1)[0]:
                 motor_state = 1
                 force, torque = self.tumble()
@@ -136,7 +150,7 @@ class MotorActivity(Process):
 
         elif motor_state == 1:  # 1 for tumble
             # switch to run?
-            prob_switch = self.parameters['cw_to_ccw'] * timestep
+            prob_switch = cw_to_ccw * timestep
             if prob_switch <= np.random.random(1)[0]:
                 motor_state = 0
                 force, torque = self.run()
@@ -148,19 +162,36 @@ class MotorActivity(Process):
             'internal': {
                 'motile_force': force,
                 'motile_torque': torque,
-                'motor_state': motor_state}
+                'motor_state': motor_state,
+                'CheY_P': CheY_P}
         }
 
         return update
 
     def tumble(self):
-        # print('motor state: TUMBLE!')
+        print('motor state: TUMBLE!')
         force = 5.0
         torque = random.normalvariate(0, TUMBLE_JITTER)
         return force, torque
 
     def run(self):
-        # print('motor state: RUN!')
+        print('motor state: RUN!')
         force = 15.0
         torque = 0.0
         return force, torque
+
+
+def test_motor():
+    motor = MotorActivity()
+    state = motor.default_state()
+    receptor_activities = [0.0, 1./3., 1.0]
+    timestep = 1
+    for activity in receptor_activities:
+        state['internal']['chemoreceptor_activity'] = activity
+
+        update = motor.next_update(timestep, state)
+
+        # TODO -- test update, make assert
+
+if __name__ == '__main__':
+    test_motor()

--- a/lens/processes/Vladimirov2008_motor.py
+++ b/lens/processes/Vladimirov2008_motor.py
@@ -6,7 +6,7 @@ import random
 from lens.actor.process import Process, dict_merge
 
 
-    TUMBLE_JITTER = 1.0  # (radians)
+TUMBLE_JITTER = 1.0  # (radians)
 
 # parameters
 DEFAULT_PARAMETERS = {

--- a/lens/processes/Vladimirov2008_motor.py
+++ b/lens/processes/Vladimirov2008_motor.py
@@ -6,18 +6,18 @@ import random
 from lens.actor.process import Process, dict_merge
 
 
-TUMBLE_JITTER = 0.5  # (radians)
+    TUMBLE_JITTER = 1.0  # (radians)
 
 # parameters
 DEFAULT_PARAMETERS = {
-    'k_A': 5.0,  #
+    # 'k_A': 5.0,  #
     'k_y': 100.0,  # 1/uM/s
     'k_z': 30.0,  # / CheZ,
     'gamma_Y': 0.1,
     'k_s': 0.45,  # scaling coefficient
     'adaptPrecision': 3,
     # motor
-    'mb_0': 0.65,
+    'mb_0': 0.65,  # steady state motor bias (Cluzel et al 2000)
     'n_motors': 5,
     'cw_to_ccw': 0.83,  # 1/s (Block1983) motor bias, assumed to be constant
 }
@@ -25,10 +25,10 @@ DEFAULT_PARAMETERS = {
 ##initial state
 INITIAL_STATE = {
     # response regulator proteins
-    'CheY_tot': 0.0097,  # (mM) 9.7 uM = 0.0097 mM
+    'CheY_tot': 9.7,  # (uM) #0.0097,  # (mM) 9.7 uM = 0.0097 mM
     'CheY_P': 0.0,
-    'CheZ': 0.1,  # phosphatase 100 uM = 0.1 mM (from RapidCell1.4.2)
-    'CheA': 0.1,  # 100 uM = 0.1 mM (from RapidCell1.4.2)
+    'CheZ': 0.01*100,  # (uM) #phosphatase 100 uM = 0.1 mM (0.01 scaling from RapidCell1.4.2)
+    'CheA': 0.01*100,  # (uM) #100 uM = 0.1 mM (0.01 scaling from RapidCell1.4.2)
     # sensor activity
     'chemoreceptor_activity': 1/3,
     # motor activity
@@ -51,6 +51,8 @@ class MotorActivity(Process):
                          'CheZ',
                          'CheY_tot',
                          'CheY_P',
+                         'ccw_motor_bias',
+                         'ccw_to_cw',
                          'motile_force',
                          'motile_torque',
                          'motor_state'],
@@ -74,7 +76,14 @@ class MotorActivity(Process):
 
     def default_emitter_keys(self):
         keys = {
-            'internal': ['motile_force', 'motile_torque', 'motor_state', 'CheA', 'CheY_P'],
+            'internal': [
+                'ccw_motor_bias',
+                'ccw_to_cw',
+                'motile_force',
+                'motile_torque',
+                'motor_state',
+                'CheA',
+                'CheY_P'],
             'external': [],
         }
         return keys
@@ -83,7 +92,14 @@ class MotorActivity(Process):
         '''
         define the updater type for each state in roles.
         The default updater is to pass a delta'''
-        set_states = ['motile_force', 'motile_torque', 'motor_state', 'CheA', 'CheY_P']
+        set_states = [
+            'ccw_motor_bias',
+            'ccw_to_cw',
+            'motile_force',
+            'motile_torque',
+            'motor_state',
+            'CheA',
+            'CheY_P']
         updater_types = {
             'internal': {state_id: 'set' for state_id in set_states},
             'external': {}}
@@ -105,16 +121,11 @@ class MotorActivity(Process):
         '''
 
         internal = states['internal']
-        # external = states['external']
-        P_on = internal['chemoreceptor_activity'] # this comes from chemoreceptor
+        P_on = internal['chemoreceptor_activity']
         motor_state = internal['motor_state']
-        CheZ = internal['CheZ']
-        CheY_tot = internal['CheY_tot']
-        CheA_tot = internal['CheA']
 
         # parameters
         adaptPrecision = self.parameters['adaptPrecision']
-        k_A = self.parameters['k_A']
         k_y = self.parameters['k_y']
         k_s = self.parameters['k_s']
         k_z = self.parameters['k_z']
@@ -123,26 +134,20 @@ class MotorActivity(Process):
         cw_to_ccw = self.parameters['cw_to_ccw']
 
         ## Kinase activity
-        CheA_P = CheA_tot * P_on * k_A / (P_on * k_A + k_y * CheY_tot)  # amount of phosphorylated CheA
-
-        # relative steady-state concentration of phosphorylated CheY.
-        # CheA_P assumed to be equal to the activity of the receptor complex (P_on)
-        # CheY_P = adaptPrecision * k_y * k_s * P_on / (k_y * k_s * P_on + k_z * CheZ + gamma_Y)
-        # scaling = 1.0688 # 19.3610  # scales CheY_P linearly so that CheY_P=1 at rest (P_on=1/3)
-        CheY_P = adaptPrecision * k_y * k_s * CheA_P / (k_y * k_s * CheA_P + k_z * CheZ + gamma_Y)
-
-        # CheB phosphorylation
-        # CheB_P = CheB_tot * P_on / (P_on + self.parameters['k_0.5'])
+        # relative steady-state concentration of phosphorylated CheY. Assumes Che_P = P_on
+        scaling = 1.  # 1.66889  # 19.3610  # scales CheY_P linearly so that CheY_P=1 at rest (P_on=1/3)
+        CheY_P = adaptPrecision * scaling * k_y * k_s * P_on / (k_y * k_s * P_on + k_z + gamma_Y)  # CheZ cancels out of k_z
 
         ## Motor switching
         # CCW corresponds to run. CW corresponds to tumble
-        ccw_motor_bias = mb_0 / (CheY_P/CheY_tot * (1 - mb_0) + mb_0)
+        ccw_motor_bias = mb_0 / (CheY_P * (1 - mb_0) + mb_0)
         ccw_to_cw = cw_to_ccw * (1 / ccw_motor_bias - 1)
 
+        # TODO -- timestep dependence
         if motor_state == 0:  # 0 for run
             # switch to tumble?
-            prob_switch = ccw_to_cw * timestep
-            if prob_switch <= np.random.random(1)[0]:
+            prob_switch = ccw_to_cw
+            if np.random.random(1)[0] <= prob_switch:
                 motor_state = 1
                 force, torque = self.tumble()
             else:
@@ -150,48 +155,116 @@ class MotorActivity(Process):
 
         elif motor_state == 1:  # 1 for tumble
             # switch to run?
-            prob_switch = cw_to_ccw * timestep
-            if prob_switch <= np.random.random(1)[0]:
+            prob_switch = ccw_motor_bias
+            if np.random.random(1)[0] <= prob_switch:
                 motor_state = 0
                 force, torque = self.run()
             else:
                 force, torque = self.tumble()
 
-        # TODO -- should force/torque be accumulated over exchange timestep?
+        # TODO -- should force/torque accumulate over exchange timestep?
         update = {
             'internal': {
+                'ccw_motor_bias': ccw_motor_bias,
+                'ccw_to_cw': ccw_to_cw,
                 'motile_force': force,
                 'motile_torque': torque,
                 'motor_state': motor_state,
-                'CheY_P': CheY_P}
+                'CheY_P': CheY_P
+            }
         }
-
         return update
 
     def tumble(self):
-        print('motor state: TUMBLE!')
-        force = 5.0
+        force = 3.0  # 5.0
         torque = random.normalvariate(0, TUMBLE_JITTER)
         return force, torque
 
     def run(self):
-        print('motor state: RUN!')
-        force = 15.0
+        force = 8.0  # 15.0
         torque = 0.0
         return force, torque
 
 
 def test_motor():
+    # TODO -- make plotting optional
+    # TODO -- add asserts for test
+
+    from numpy import linspace
+
     motor = MotorActivity()
     state = motor.default_state()
-    receptor_activities = [0.0, 1./3., 1.0]
     timestep = 1
+    receptor_activities = linspace(0.0, 1.0, 501).tolist()
+    CheY_P_vec = []
+    ccw_motor_bias_vec = []
+    ccw_to_cw_vec = []
+    motor_state_vec = []
     for activity in receptor_activities:
         state['internal']['chemoreceptor_activity'] = activity
-
         update = motor.next_update(timestep, state)
+        CheY_P = update['internal']['CheY_P']
+        ccw_motor_bias = update['internal']['ccw_motor_bias']
+        ccw_to_cw = update['internal']['ccw_to_cw']
+        motile_state = update['internal']['motor_state']
 
-        # TODO -- test update, make assert
+        CheY_P_vec.append(CheY_P)
+        ccw_motor_bias_vec.append(ccw_motor_bias)
+        ccw_to_cw_vec.append(ccw_to_cw)
+        motor_state_vec.append(motile_state)
+
+    return {
+        'receptor_activities': receptor_activities,
+        'CheY_P_vec': CheY_P_vec,
+        'ccw_motor_bias_vec': ccw_motor_bias_vec,
+        'ccw_to_cw_vec': ccw_to_cw_vec,
+        'motor_state_vec': motor_state_vec}
+
+def plot_output(output):
+    import os
+    import matplotlib
+    matplotlib.use('TkAgg')
+    import matplotlib.pyplot as plt
+
+    receptor_activities = output['receptor_activities']
+    CheY_P_vec = output['CheY_P_vec']
+    ccw_motor_bias_vec = output['ccw_motor_bias_vec']
+    ccw_to_cw_vec = output['ccw_to_cw_vec']
+    motor_state_vec = output['motor_state_vec']
+
+    # plot results
+    cols = 1
+    rows = 4
+    plt.figure(figsize=(6 * cols, 1 * rows))
+
+    ax1 = plt.subplot(rows, cols, 1)
+    ax2 = plt.subplot(rows, cols, 2)
+    ax3 = plt.subplot(rows, cols, 3)
+    ax4 = plt.subplot(rows, cols, 4)
+
+    ax1.plot(receptor_activities, 'b')
+    ax2.plot(CheY_P_vec, 'b')
+    ax3.plot(ccw_motor_bias_vec, 'b', label='ccw_motor_bias')
+    ax3.plot(ccw_to_cw_vec, 'g', label='ccw_to_cw')
+    ax4.plot(motor_state_vec, '.b')
+
+    ax1.set_xticklabels([])
+    ax1.set_ylabel("receptor activity \n P(on) ", fontsize=10)
+    ax2.set_xticklabels([])
+    ax2.set_ylabel("CheY_P", fontsize=10)
+    ax3.set_xticklabels([])
+    ax3.set_ylabel("motor bias", fontsize=10)
+    ax3.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    ax4.set_yticks([0.0, 1.0])
+    ax4.set_yticklabels(["run", "tumble"])
+
+    OUTPUT_PLOT = os.path.join(
+        'out', 'Vladimirov2008_motor_test'
+    )
+    plt.subplots_adjust(wspace=0.7, hspace=0.1)
+    plt.savefig(OUTPUT_PLOT + '.png', bbox_inches='tight')
+
 
 if __name__ == '__main__':
-    test_motor()
+    output = test_motor()
+    plot_output(output)


### PR DESCRIPTION
This PR tunes the chemotaxis composite, which is now fully operational.  There are two processes that go into it: chemoreceptors (Endres & Wingreen 2006) and motor activity (Vladimirov 2008). Each of these processes now has tests, though I still need to add asserts within the test. If the processes are called, they run the test and save output.  

Example output for the chemoreceptor's test:
![Endres2006_chemoreceptor_test](https://user-images.githubusercontent.com/6809431/66676345-1c53bc80-ec1c-11e9-874f-8f4329750c65.png)

The composite successfully navigates to regions of higher ligand concentrations. In the ```analyze_lattice``` output shown below, the region of high ligand concentrations is right in the middle of lattice. This behavior still needs to be compared to experimental data and fine-tuned.
![location_trace](https://user-images.githubusercontent.com/6809431/66676416-42795c80-ec1c-11e9-9f33-298a3e5c79f7.png)

The analysis of all states emitted from the chemotaxis composite make the following ```analyze_compartment``` output
![compartment](https://user-images.githubusercontent.com/6809431/66676779-1ca08780-ec1d-11e9-9300-51f2b8f894fd.png)
