### PR TITLE
membrane potential

### DIFF
--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -37,6 +37,7 @@ from lens.processes.Kremling2007_transport import Transport
 from lens.processes.growth import Growth
 from lens.processes.Endres2006_chemoreceptor import ReceptorCluster
 from lens.processes.Vladimirov2008_motor import MotorActivity
+from lens.processes.proton_motive_force import ProtonMotiveForce
 
 # composites
 from lens.composites.Covert2002_rFBA import compose_covert2002
@@ -359,6 +360,7 @@ class BootEnvironment(BootAgent):
             'growth': wrap_boot(wrap_init_basic(Growth), {'volume': 1.0}),
             'receptor': wrap_boot(wrap_init_basic(ReceptorCluster), {'volume': 1.0}),
             'motor': wrap_boot(wrap_init_basic(MotorActivity), {'volume': 1.0}),
+            'PMF': wrap_boot(wrap_init_basic(ProtonMotiveForce), {'volume': 1.0}),
 
             # composite compartments
             'growth_division': wrap_boot(wrap_init_composite(compose_growth_division), {'volume': 1.0}),

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -38,7 +38,7 @@ from lens.processes.growth import Growth
 from lens.processes.protein_expression import ProteinExpression
 from lens.processes.Endres2006_chemoreceptor import ReceptorCluster
 from lens.processes.Vladimirov2008_motor import MotorActivity
-from lens.processes.proton_motive_force import ProtonMotiveForce
+from lens.processes.membrane_potential import MembranePotential
 
 # composites
 from lens.composites.Covert2002_rFBA import compose_covert2002
@@ -359,7 +359,7 @@ class BootEnvironment(BootAgent):
             'expression': wrap_boot(wrap_init_basic(ProteinExpression), {'volume': 1.0}),
             'receptor': wrap_boot(wrap_init_basic(ReceptorCluster), {'volume': 1.0}),
             'motor': wrap_boot(wrap_init_basic(MotorActivity), {'volume': 1.0}),
-            'PMF': wrap_boot(wrap_init_basic(ProtonMotiveForce), {'volume': 1.0}),
+            'membrane_potential': wrap_boot(wrap_init_basic(MembranePotential), {'volume': 1.0}),
 
             # composite compartments
             'growth_division': wrap_boot(wrap_init_composite(compose_growth_division), {'volume': 1.0}),

--- a/lens/processes/membrane_potential.py
+++ b/lens/processes/membrane_potential.py
@@ -7,15 +7,15 @@ from lens.actor.process import Process
 from lens.utils.units import units
 
 
-class ProtonMotiveForce(Process):
+class MembranePotential(Process):
     '''
     Need to add a boot method for this process to lens/environment/boot.py for it to run on its own
     '''
     def __init__(self, initial_parameters={}):
 
         parameters = {
-            'R': 8.314462618,  # (kg * m^2 * s^-2 * K^-1 * mol^-1) gas constant
-            'F': 96485.33289, # (charge / mol)  Faraday constant
+            'R': 8.314462618,  # (J * K^-1 * mol^-1) gas constant
+            'F': 96485.33289, # (charge * mol^-1)  Faraday constant
             'p_K': 0.05,  # (unitless, relative permeability) membrane permeability of K
             'p_Na': 0.05,  # (unitless, relative permeability) membrane permeability of Na
             'p_Cl': 0.05,  # (unitless, relative permeability) membrane permeability of Cl
@@ -28,7 +28,7 @@ class ProtonMotiveForce(Process):
         }
         parameters.update(initial_parameters)
 
-        super(ProtonMotiveForce, self).__init__(roles, parameters)
+        super(MembranePotential, self).__init__(roles, parameters)
 
     def default_state(self):
         '''
@@ -40,7 +40,7 @@ class ProtonMotiveForce(Process):
         return {
             'internal': {'K': 1, 'Na': 1, 'Cl': 1},
             # 'membrane': {'V_m': },
-            'external': {'K': 1, 'Na': 1, 'Cl': 1, 'T': 37}
+            'external': {'K': 1, 'Na': 1, 'Cl': 1, 'T': 310.15}  # temperature in Kelvin
         }
 
     def default_emitter_keys(self):
@@ -108,10 +108,10 @@ def test_PMF():
     ]
 
     # configure process
-    PMF = ProtonMotiveForce({})
+    mp = MembranePotential({})
 
     # get initial state and parameters
-    state = PMF.default_state()
+    state = mp.default_state()
     saved_state = {'internal': {}, 'external': {}, 'membrane': {}, 'time': []}
 
     # run simulation
@@ -124,7 +124,7 @@ def test_PMF():
                 for key, change in change_dict.iteritems():
                     state[key].update(change)
 
-        update = PMF.next_update(timestep, state)
+        update = mp.next_update(timestep, state)
         saved_state['time'].append(time)
 
         # update external state

--- a/lens/processes/proton_motive_force.py
+++ b/lens/processes/proton_motive_force.py
@@ -1,0 +1,84 @@
+from __future__ import absolute_import, division, print_function
+
+from lens.actor.process import Process
+from lens.utils.units import units
+
+
+class ProtonMotiveForce(Process):
+    '''
+    Need to add a boot method for this process to lens/environment/boot.py for it to run on its own
+    '''
+    def __init__(self, initial_parameters={}):
+
+        parameters = {
+            'F': 96485.33289, # (charge / mol)  Faraday constant
+        }
+
+
+        roles = {
+            'internal': ['Q_in'],
+            'membrane': ['V_m'],
+            'external': [],
+        }
+        parameters.update(initial_parameters)
+
+        super(ProtonMotiveForce, self).__init__(roles, parameters)
+
+    def default_state(self):
+        '''
+        returns dictionary with:
+        default_state = {
+            'external': states (dict) -- external states ids with default initial values
+            'internal': states (dict) -- internal states ids with default initial values
+        '''
+
+        return {
+            'internal': {},
+            'membrane': {},
+            'external': {},
+        }
+
+    def default_emitter_keys(self):
+        '''
+        returns dictionary with:
+        keys = {
+            'internal': states (list), # a list of states to emit from internal
+            'external': states (list), # a list of states to emit from external
+        }
+        '''
+        keys = {
+            'internal': [],
+            'membrane': [],
+            'external': [],
+        }
+        return keys
+
+    def default_updaters(self):
+        '''
+        define the updater type for each state in roles.
+        The default updater is to pass a delta,
+        which is accumulated and passed to the environment at every exchange step'''
+        keys = {
+            'membrane': {
+                'V_m': 'accumulate'}}
+        return keys
+
+    def next_update(self, timestep, states):
+        internal_state = states['internal']
+        external_state = states['external']
+
+        Q_in = internal_state['Q_in']
+
+        # V_m = electric potential difference
+        # Q_in is the intracellular charge (in mole)
+        # C is the membrane capacitance
+        # F is the Faraday constant
+        V_m = self.parameters['F'] * Q_in / C
+
+
+        update = {
+            # 'internal': {},
+            'membrane': {'V_m': V_m},
+            # 'external': {},
+        }
+        return update

--- a/lens/processes/proton_motive_force.py
+++ b/lens/processes/proton_motive_force.py
@@ -15,8 +15,10 @@ class ProtonMotiveForce(Process):
 
         parameters = {
             'R': 8.314462618,  # (kg * m^2 * s^-2 * K^-1 * mol^-1) gas constant
-            'z': 1,  # valence of charge molecule  # TODO -- get this
             'F': 96485.33289, # (charge / mol)  Faraday constant
+            'p_K': 0.05,  # (unitless, relative permeability) membrane permeability of K
+            'p_Na': 0.05,  # (unitless, relative permeability) membrane permeability of Na
+            'p_Cl': 0.05,  # (unitless, relative permeability) membrane permeability of Cl
         }
 
         roles = {
@@ -36,9 +38,9 @@ class ProtonMotiveForce(Process):
             'internal': states (dict) -- internal states ids with default initial values
         '''
         return {
-            'internal': {'c_in': 1.1},
+            'internal': {'K': 1, 'Na': 1, 'Cl': 1},
             # 'membrane': {'V_m': },
-            'external': {'c_out': 1, 'T': 37}
+            'external': {'K': 1, 'Na': 1, 'Cl': 1, 'T': 37}
         }
 
     def default_emitter_keys(self):
@@ -70,19 +72,25 @@ class ProtonMotiveForce(Process):
 
         # parameters
         R = self.parameters['R']  # gas constant
-        z = self.parameters['z']  # valence of charged molecule
         F = self.parameters['F']  # Faraday constant
+        p_K = self.parameters['p_K']  # Faraday constant
+        p_Na = self.parameters['p_Na']  # Faraday constant
+        p_Cl = self.parameters['p_Cl']  # Faraday constant
 
         # state
-        c_in = internal_state['c_in']  # internal concentration of charged molecule
-        c_out = external_state['c_out']  # internal concentration of charged molecule
+        K_in = internal_state['K']
+        Na_in = internal_state['Na']
+        Cl_in = internal_state['Cl']
+        K_out = external_state['K']
+        Na_out = external_state['Na']
+        Cl_out = external_state['Cl']
+
         T = external_state['T']  # temperature
 
-        # TODO -- what if multiple charged molecules?
-
-        # Membrane potential Pilizota
-        V_m = (R * T) / (z * F) * np.log(c_out / c_in)
-
+        # Goldman equation
+        numerator = p_K * K_out + p_Na * Na_out + p_Cl * Cl_in
+        denominator = p_K * K_in + p_Na * Na_in + p_Cl * Cl_out
+        V_m = (R * T) / (F) * np.log(numerator / denominator)
 
         update = {
             # 'internal': {},

--- a/lens/processes/proton_motive_force.py
+++ b/lens/processes/proton_motive_force.py
@@ -150,9 +150,22 @@ def plot_PMF(saved_state, out_dir='out'):
     fig = plt.figure(figsize=(8, n_rows * 2.5))
     grid = plt.GridSpec(n_rows + 1, 1, wspace=0.4, hspace=1.5)
 
-    # plot
-    # TODO
+    # plot data
+    plot_idx = 0
+    for key in data_keys:
+        for mol_id, series in sorted(saved_state[key].iteritems()):
+            ax = fig.add_subplot(grid[plot_idx, 0])  # grid is (row, column)
 
+            ax.plot(time_vec, series)
+            ax.title.set_text(str(key) + ': ' + mol_id)
+            # ax.yaxis.set_major_formatter(FormatStrFormatter('%.3f'))
+            ax.set_xlabel('time (hrs)')
+
+            if key is 'internal':
+                ax.set_yticks([0.0, 1.0])
+                ax.set_yticklabels(["False", "True"])
+
+            plot_idx += 1
     # save figure
     fig_path = os.path.join(out_dir, 'PMF')
     plt.subplots_adjust(wspace=0.5, hspace=0.5)


### PR DESCRIPTION
Here, a membrane potential process is introduced, which is calculated from internal/external concentrations of the ions Na, Cl, K. With this process alone, membrane potential should remain fixed as no ions move across the membrane. A separate process can be used to pump ions across the membrane, for example with ATP synthase, proton pumps, and flagellar activity.