### PR TITLE
test transport

### DIFF
--- a/lens/utils/flux_conversion.py
+++ b/lens/utils/flux_conversion.py
@@ -50,6 +50,20 @@ def counts_to_molar(counts, volume):
     # volume = cell_mass / density
     return counts / (nAvogadro * volume)
 
+
+def counts_to_millimolar(counts, volume):
+    '''
+    input:
+        counts -- list
+        volume -- list (L)
+
+    return:
+        fluxes -- list (molar)
+    '''
+    # volume = cell_mass / density
+    return counts / (nAvogadro * volume * 1e-3)
+
+
 def molar_to_molDCWhr(fluxes, dry_mass, cell_mass, density, timestep):
     '''
     input:


### PR DESCRIPTION
This adds a test to the transport process, and applies the updaters to `set` internal concentrations and `accumulate` external counts.

The test output plots a time series for all relevant states: 
[transport.pdf](https://github.com/CovertLab/Lens/files/3825941/transport.pdf)