### PR TITLE
Encode processes in layers of simultaneous events rather than one simultaneous event

### DIFF
--- a/lens/actor/emitter.py
+++ b/lens/actor/emitter.py
@@ -5,6 +5,7 @@ from confluent_kafka import Producer
 import json
 
 from lens.actor.actor import delivery_report
+from lens.utils.dict_utils import merge_dicts
 
 HISTORY_INDEXES = [
     'time',
@@ -46,9 +47,10 @@ def get_emitter(config):
         'object': emitter,
         'keys': config.get('keys')}
 
-def get_emitter_keys(processes, topology):
+def get_emitter_keys(process, topology):
     emitter_keys = {}
-    for process_id, process_object in processes.iteritems():
+
+    for process_id, process_object in merge_dicts(process).items():
         process_roles = topology[process_id]
         process_keys = process_object.default_emitter_keys()
         for role, keys in process_keys.iteritems():

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -11,9 +11,6 @@ from lens.utils.dict_utils import merge_dicts
 target_key = '__target'
 exchange_key = '__exchange'  # TODO exchange key is also being set in lattice_compartment
 
-class StateError(Exception):
-    pass
-
 def npize(d):
     ''' Turn a dict into an ordered set of keys and values. '''
 
@@ -96,8 +93,7 @@ class State(object):
             return np.array([])
         if not all([item for item in np.isin(keys, self.keys)]):
             invalid_states = np.setdiff1d(keys, self.keys)
-            raise StateError("no state for {}".format(invalid_states))
-
+            print("no state for {}".format(invalid_states))
         return np.searchsorted(self.keys, keys)
 
     def assign_values(self, values_dict):

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -245,14 +245,14 @@ def merge_default_states(processes):
     initial_state = {}
     for process_id, process in merge_dicts(processes).items():
         default = process.default_state()
-        initial_state = dict_merge(dict(initial_state), default)
+        initial_state = deep_merge(dict(initial_state), default)
     return initial_state
 
 def merge_default_updaters(processes):
     updaters = {}
     for process_id, process in merge_dicts(processes).items():
         process_updaters = process.default_updaters()
-        updaters = dict_merge(dict(updaters), process_updaters)
+        updaters = deep_merge(dict(updaters), process_updaters)
     return updaters
 
 def merge_dicts(dicts):
@@ -261,15 +261,15 @@ def merge_dicts(dicts):
         merge.update(d)
     return merge
 
-def dict_merge(dct, merge_dct):
+def deep_merge(dct, merge_dct):
     '''
     Recursive dict merge
     This mutates dct - the contents of merge_dct are added to dct (which is also returned).
-    If you want to keep dct you could call it like dict_merge(dict(dct), merge_dct)'''
+    If you want to keep dct you could call it like deep_merge(dict(dct), merge_dct)'''
     for k, v in merge_dct.items():
         if (k in dct and isinstance(dct[k], dict)
                 and isinstance(merge_dct[k], collections.Mapping)):
-            dict_merge(dct[k], merge_dct[k])
+            deep_merge(dct[k], merge_dct[k])
         else:
             dct[k] = merge_dct[k]
     return dct

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -15,7 +15,7 @@ class StateError(Exception):
 def npize(d):
     ''' Turn a dict into an ordered set of keys and values. '''
 
-    ordered = [[key, value] for key, value in d.iteritems()]
+    ordered = [[key, value] for key, value in d.items()]
     keys = [key for key, _ in ordered]
     values = np.array([value for _, value in ordered], np.float64)
 
@@ -92,7 +92,7 @@ class State(object):
     def index_for(self, keys):
         if self.keys.size == 0:
             return np.array([])
-        if not all(item == True for item in np.isin(keys, self.keys)):
+        if not all([item for item in np.isin(keys, self.keys)]):
             invalid_states = np.setdiff1d(keys, self.keys)
             raise StateError("no state for {}".format(invalid_states))
 
@@ -141,7 +141,7 @@ class State(object):
                 self.new_state[index],
                 value)
 
-            for other_key, other_value in other_updates.iteritems():
+            for other_key, other_value in other_updates.items():
                 other_index = self.index_for(other_key)
                 self.new_state[other_index] = other_value
 
@@ -205,7 +205,7 @@ class Process(object):
         Roles and States must have the same keys. '''
 
         self.states = states
-        for role, state in self.states.iteritems():
+        for role, state in self.states.items():
             state.declare_state(self.roles[role])
 
     def update_for(self, timestep):
@@ -213,7 +213,7 @@ class Process(object):
 
         states = {
             role: self.states[role].state_for(self.roles[role])
-            for role, values in self.roles.iteritems()}
+            for role, values in self.roles.items()}
 
         return self.next_update(timestep, states)
 
@@ -225,31 +225,32 @@ class Process(object):
 
         return {
             role: {}
-            for role, values in self.roles.iteritems()}
+            for role, values in self.roles.items()}
 
 
-def connect_topology(processes, states, topology):
+def connect_topology(process_layers, states, topology):
     ''' Given a set of processes and states, and a description of the connections
         between them, link the roles in each process to the state they refer to.'''
 
-    for name, process in processes.iteritems():
-        connections = topology[name]
-        roles = {
-            role: states[key]
-            for role, key in connections.iteritems()}
+    for processes in process_layers:
+        for name, process in processes.items():
+            connections = topology[name]
+            roles = {
+                role: states[key]
+                for role, key in connections.items()}
 
-        process.assign_roles(roles)
+            process.assign_roles(roles)
 
 def merge_default_states(processes):
     initial_state = {}
-    for process_id, process in processes.iteritems():
+    for process_id, process in processes.items():
         default = process.default_state()
         initial_state = dict_merge(dict(initial_state), default)
     return initial_state
 
 def merge_default_updaters(processes):
     updaters = {}
-    for process_id, process in processes.iteritems():
+    for process_id, process in processes.items():
         process_updaters = process.default_updaters()
         updaters = dict_merge(dict(updaters), process_updaters)
     return updaters
@@ -259,7 +260,7 @@ def dict_merge(dct, merge_dct):
     Recursive dict merge
     This mutates dct - the contents of merge_dct are added to dct (which is also returned).
     If you want to keep dct you could call it like dict_merge(dict(dct), merge_dct)'''
-    for k, v in merge_dct.iteritems():
+    for k, v in merge_dct.items():
         if (k in dct and isinstance(dct[k], dict)
                 and isinstance(merge_dct[k], collections.Mapping)):
             dict_merge(dct[k], merge_dct[k])
@@ -295,16 +296,7 @@ class Compartment(object):
         self.local_time = 0.0
         self.time_step = configuration.get('time_step', 1.0)
 
-        self.derivers = {
-            name: process
-            for name, process in processes.iteritems()
-            if process.deriver}
-
-        self.processes = {
-            name: process
-            for name, process in processes.iteritems()
-            if not process.deriver}
-
+        self.processes = processes
         self.states = states
         self.topology = configuration['topology']
 
@@ -324,37 +316,27 @@ class Compartment(object):
             'data': {'topology': self.topology}}
         self.emitter.emit(emit_config)
 
-    def run_derivers(self, timestep):
-        ''' Run each deriver process to set up state for subsequent processes. '''
-
-        for name, deriver in self.derivers.iteritems():
-            all_updates = deriver.update_for(timestep)
-            for role, update in all_updates.iteritems():
-                key = self.topology[name][role]
-                self.states[key].assign_values(update)
-
     def update(self, timestep):
         ''' Run each process for the given time step and update the related states. '''
 
-        updates = {}
-        for name, process in self.processes.iteritems():
-            update = process.update_for(timestep)
-            for role, update_dict in update.iteritems():
-                key = self.topology[name][role]
-                if not updates.get(key):
-                    updates[key] = []
-                updates[key].append(update_dict)
+        for processes in self.processes:
+            updates = {}
+            for name, process in processes.items():
+                update = process.update_for(timestep)
+                for role, update_dict in update.items():
+                    key = self.topology[name][role]
+                    if not updates.get(key):
+                        updates[key] = []
+                    updates[key].append(update_dict)
 
-        for key in self.states.keys():
-            self.states[key].prepare()
+            for key in self.states.keys():
+                self.states[key].prepare()
 
-        for key, update in updates.iteritems():
-            self.states[key].apply_updates(update)
+            for key, update in updates.items():
+                self.states[key].apply_updates(update)
 
-        for key in self.states.keys():
-            self.states[key].proceed()
-
-        self.run_derivers(timestep)
+            for key in self.states.keys():
+                self.states[key].proceed()
 
         self.local_time += timestep
 
@@ -366,19 +348,19 @@ class Compartment(object):
 
         return {
             key: state.to_dict()
-            for key, state in self.states.iteritems()}
+            for key, state in self.states.items()}
 
     def current_parameters(self):
         return {
             name: process.parameters
-            for name, process in self.processes.iteritems()}
+            for name, process in self.processes.items()}
 
     def time(self):
         return self.initial_time + self.local_time
 
     def emit_data(self):
         data = {}
-        for role_key, emit_keys in self.emitter_keys.iteritems():
+        for role_key, emit_keys in self.emitter_keys.items():
             data[role_key] = self.states[role_key].state_for(emit_keys)
 
         data.update({
@@ -451,11 +433,18 @@ def test_compartment():
             return update
 
     # declare the processes
-    processes = {
-        'metabolism': Metabolism(initial_parameters={'mass_conversion_rate': 0.5}), # example of overriding default parameters
-        'transport': Transport(),
-        'external_volume': DeriveVolume(),
-        'internal_volume': DeriveVolume()}
+    # processes = {
+    #     'metabolism': Metabolism(initial_parameters={'mass_conversion_rate': 0.5}), # example of overriding default parameters
+    #     'transport': Transport(),
+    #     'external_volume': DeriveVolume(),
+    #     'internal_volume': DeriveVolume()}
+    processes = [
+        {'metabolism': Metabolism(
+            initial_parameters={
+                'mass_conversion_rate': 0.5}), # example of overriding default parameters
+         'transport': Transport()},
+        {'external_volume': DeriveVolume(),
+         'internal_volume': DeriveVolume()}]
 
     def update_mass(key, state, current, new):
         return current / (current + new), {}
@@ -464,10 +453,10 @@ def test_compartment():
     states = {
         'periplasm': State(
             initial_state={'GLC': 20, 'MASS': 100, 'DENSITY': 10},
-            updaters={'MASS': update_mass}),
+            updaters={'MASS': update_mass, 'VOLUME': 'set'}),
         'cytoplasm': State(
             initial_state={'MASS': 3, 'DENSITY': 10},
-            updaters={'DENSITY': 'set'})}
+            updaters={'VOLUME': 'set'})}
 
     # hook up the states to the roles in each process
     topology = {

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -178,13 +178,12 @@ class State(object):
 
 
 class Process(object):
-    def __init__(self, roles, parameters=None, deriver=False):
+    def __init__(self, roles, parameters=None):
         ''' Declare what roles this process expects. '''
 
         self.roles = roles
         self.parameters = parameters or {}
         self.states = None
-        self.deriver = deriver
 
     def default_state(self):
         return {}
@@ -428,7 +427,7 @@ def test_compartment():
                 'compartment': ['MASS', 'DENSITY', 'VOLUME']}
             parameters = {}
 
-            super(DeriveVolume, self).__init__(roles, parameters, deriver=True)
+            super(DeriveVolume, self).__init__(roles, parameters)
 
         def next_update(self, timestep, states):
             volume = states['compartment']['MASS'] / states['compartment']['DENSITY']

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -243,17 +243,23 @@ def connect_topology(process_layers, states, topology):
 
 def merge_default_states(processes):
     initial_state = {}
-    for process_id, process in processes.items():
+    for process_id, process in merge_dicts(processes).items():
         default = process.default_state()
         initial_state = dict_merge(dict(initial_state), default)
     return initial_state
 
 def merge_default_updaters(processes):
     updaters = {}
-    for process_id, process in processes.items():
+    for process_id, process in merge_dicts(processes).items():
         process_updaters = process.default_updaters()
         updaters = dict_merge(dict(updaters), process_updaters)
     return updaters
+
+def merge_dicts(dicts):
+    merge = {}
+    for d in dicts:
+        merge.update(d)
+    return merge
 
 def dict_merge(dct, merge_dct):
     '''
@@ -308,7 +314,6 @@ class Compartment(object):
         self.emitter = configuration['emitter'].get('object')
 
         connect_topology(processes, self.states, self.topology)
-        self.run_derivers(0)
 
         # log experiment configuration
         emit_config = {
@@ -353,7 +358,7 @@ class Compartment(object):
     def current_parameters(self):
         return {
             name: process.parameters
-            for name, process in self.processes.items()}
+            for name, process in merge_dicts(self.processes).items()}
 
     def time(self):
         return self.initial_time + self.local_time
@@ -432,12 +437,6 @@ def test_compartment():
 
             return update
 
-    # declare the processes
-    # processes = {
-    #     'metabolism': Metabolism(initial_parameters={'mass_conversion_rate': 0.5}), # example of overriding default parameters
-    #     'transport': Transport(),
-    #     'external_volume': DeriveVolume(),
-    #     'internal_volume': DeriveVolume()}
     processes = [
         {'metabolism': Metabolism(
             initial_parameters={

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -5,6 +5,8 @@ import numpy as np
 import lens.actor.emitter as emit
 import random
 
+from lens.utils.dict_utils import merge_dicts
+
 
 target_key = '__target'
 exchange_key = '__exchange'  # TODO exchange key is also being set in lattice_compartment
@@ -253,12 +255,6 @@ def merge_default_updaters(processes):
         process_updaters = process.default_updaters()
         updaters = deep_merge(dict(updaters), process_updaters)
     return updaters
-
-def merge_dicts(dicts):
-    merge = {}
-    for d in dicts:
-        merge.update(d)
-    return merge
 
 def deep_merge(dct, merge_dct):
     '''

--- a/lens/analysis/multigen_compartment.py
+++ b/lens/analysis/multigen_compartment.py
@@ -5,7 +5,7 @@ from matplotlib.ticker import FormatStrFormatter
 import numpy as np
 
 from lens.analysis.analysis import Analysis, get_compartment
-from lens.actor.process import dict_merge
+from lens.actor.process import deep_merge
 
 class MultigenCompartment(Analysis):
     def __init__(self):

--- a/lens/analysis/snapshots.py
+++ b/lens/analysis/snapshots.py
@@ -6,7 +6,7 @@ import matplotlib.patches as patches
 from matplotlib.colors import hsv_to_rgb
 
 from lens.analysis.analysis import Analysis, get_compartment
-from lens.actor.process import dict_merge
+from lens.actor.process import deep_merge
 
 # DEFAULT_COLOR = [color/255 for color in [102, 178, 255]]
 DEFAULT_COLOR = [220/360, 100.0/100.0, 50.0/100.0]  # HSV
@@ -36,7 +36,7 @@ class Snapshots(Analysis):
             time_dict = {time: {} for time in times}
             for tag, series in tags_history.iteritems():
                 tag_hist = {time: {'tags': {tag: state}} for time, state in zip(times,series)}
-                time_dict = dict_merge(dict(time_dict), tag_hist)
+                time_dict = deep_merge(dict(time_dict), tag_hist)
 
             return time_dict
 
@@ -124,7 +124,7 @@ class Snapshots(Analysis):
                     tdata = tags_data[agent_id]
                     tags = tdata.get(time) or tdata[min(tdata.keys(), key=lambda k: abs(k-time))]  # get closest time key
                     agent_tags[agent_id] = tags
-                agent_data = dict_merge(dict(agent_data), agent_tags)
+                agent_data = deep_merge(dict(agent_data), agent_tags)
 
             if field_ids:
                 # plot fields

--- a/lens/composites/Chemotaxis.py
+++ b/lens/composites/Chemotaxis.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge, merge_dicts
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
+from lens.utils.dict_utils import merge_dicts
 
 # processes
 from lens.processes.Endres2006_chemoreceptor import ReceptorCluster

--- a/lens/composites/Chemotaxis.py
+++ b/lens/composites/Chemotaxis.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, dict_merge
+from lens.actor.process import State, merge_default_states, merge_default_updaters, dict_merge, merge_dicts
 
 # processes
 from lens.processes.Endres2006_chemoreceptor import ReceptorCluster
@@ -15,11 +15,11 @@ def compose_chemotaxis(config):
     receptor = ReceptorCluster(config)
     motor = MotorActivity(config)
     # deriver = DeriveVolume(config)
-    processes = {
+    processes = [{
         'receptor': receptor,
         'motor': motor,
         # 'deriver': deriver
-    }
+    }]
 
     # initialize the states
     default_states = merge_default_states(processes)
@@ -30,12 +30,12 @@ def compose_chemotaxis(config):
     # get environment ids, and make exchange_ids for external state
     environment_ids = []
     initial_exchanges = {}
-    for process_id, process in processes.iteritems():
+    for process_id, process in merge_dicts(processes).items():
         roles = {role: {} for role in process.roles.keys()}
         initial_exchanges.update(roles)
 
-    for role, state_ids in default_updaters.iteritems():
-        for state_id, updater in state_ids.iteritems():
+    for role, state_ids in default_updaters.items():
+        for state_id, updater in state_ids.items():
             if updater is 'accumulate':
                 environment_ids.append(state_id)
                 initial_exchanges[role].update({state_id + exchange_key: 0.0})

--- a/lens/composites/Chemotaxis.py
+++ b/lens/composites/Chemotaxis.py
@@ -70,7 +70,7 @@ def compose_chemotaxis(config):
 
     options = {
         'topology': topology,
-		'initial_time': initial_time,
+        'initial_time': initial_time,
         'environment': 'environment',
         'compartment': 'cell',
         'environment_ids': environment_ids,

--- a/lens/composites/Chemotaxis.py
+++ b/lens/composites/Chemotaxis.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, dict_merge, merge_dicts
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge, merge_dicts
 
 # processes
 from lens.processes.Endres2006_chemoreceptor import ReceptorCluster
@@ -40,7 +40,7 @@ def compose_chemotaxis(config):
                 environment_ids.append(state_id)
                 initial_exchanges[role].update({state_id + exchange_key: 0.0})
 
-    default_states = dict_merge(default_states, initial_exchanges)
+    default_states = deep_merge(default_states, initial_exchanges)
 
     # set states according to the compartment_roles mapping.
     # This will not generalize to composites with processes that have different roles
@@ -50,7 +50,7 @@ def compose_chemotaxis(config):
 
     states = {
         compartment_roles[role]: State(
-            initial_state=dict_merge(
+            initial_state=deep_merge(
                 default_states.get(role, {}),
                 dict(initial_state.get(compartment_roles[role], {}))),
             updaters=default_updaters.get(role, {}))

--- a/lens/composites/Covert2002_rFBA.py
+++ b/lens/composites/Covert2002_rFBA.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge, merge_dicts
 
 # processes
 from lens.processes.CovertPalsson2002_metabolism import Covert2002Metabolism
@@ -15,10 +15,10 @@ def compose_covert2002(config):
     metabolism = Covert2002Metabolism(config)
     regulation = Regulation(config)
     deriver = DeriveVolume(config)
-    processes = {
-        'regulation': regulation,
-        'metabolism': metabolism,
-        'deriver': deriver}
+    processes = [
+        {'regulation': regulation,
+         'metabolism': metabolism},
+        {'deriver': deriver}]
 
     # initialize the states
     default_states = merge_default_states(processes)
@@ -29,7 +29,7 @@ def compose_covert2002(config):
     # get environment ids, and make exchange_ids for external state
     environment_ids = []
     initial_exchanges = {}
-    for process_id, process in processes.iteritems():
+    for process_id, process in merge_dicts(processes).iteritems():
         roles = {role: {} for role in process.roles.keys()}
         initial_exchanges.update(roles)
 

--- a/lens/composites/Covert2002_rFBA.py
+++ b/lens/composites/Covert2002_rFBA.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, dict_merge
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
 
 # processes
 from lens.processes.CovertPalsson2002_metabolism import Covert2002Metabolism
@@ -39,7 +39,7 @@ def compose_covert2002(config):
                 environment_ids.append(state_id)
                 initial_exchanges[role].update({state_id + exchange_key: 0.0})
 
-    default_states = dict_merge(default_states, initial_exchanges)
+    default_states = deep_merge(default_states, initial_exchanges)
 
     # set states according to the compartment_roles mapping.
     # This will not generalize to composites with processes that have different roles
@@ -49,7 +49,7 @@ def compose_covert2002(config):
 
     states = {
         compartment_roles[role]: State(
-            initial_state=dict_merge(
+            initial_state=deep_merge(
                 default_states[role],
                 dict(initial_state.get(compartment_roles[role], {}))),
             updaters=default_updaters.get(role, {}))

--- a/lens/composites/Covert2002_rFBA.py
+++ b/lens/composites/Covert2002_rFBA.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge, merge_dicts
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
+from lens.utils.dict_utils import merge_dicts
 
 # processes
 from lens.processes.CovertPalsson2002_metabolism import Covert2002Metabolism

--- a/lens/composites/Covert2008_iFBA.py
+++ b/lens/composites/Covert2008_iFBA.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, dict_merge
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
 
 # processes
 from lens.processes.CovertPalsson2002_metabolism import Covert2002Metabolism
@@ -42,7 +42,7 @@ def compose_covert2008(config):
                 environment_ids.append(state_id)
                 initial_exchanges[role].update({state_id + exchange_key: 0.0})
 
-    default_states = dict_merge(default_states, initial_exchanges)
+    default_states = deep_merge(default_states, initial_exchanges)
 
     # set states according to the compartment_roles mapping.
     # This will not generalize to composites with processes that have different roles
@@ -52,7 +52,7 @@ def compose_covert2008(config):
 
     states = {
         compartment_roles[role]: State(
-            initial_state=dict_merge(
+            initial_state=deep_merge(
                 default_states[role],
                 dict(initial_state.get(compartment_roles[role], {}))),
             updaters=default_updaters.get(role, {}))

--- a/lens/composites/Covert2008_iFBA.py
+++ b/lens/composites/Covert2008_iFBA.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge, merge_dicts
 
 # processes
 from lens.processes.CovertPalsson2002_metabolism import Covert2002Metabolism
@@ -17,11 +17,11 @@ def compose_covert2008(config):
     metabolism = Covert2002Metabolism(config)
     regulation = Regulation(config)
     deriver = DeriveVolume(config)
-    processes = {
-        'transport': transport,
-        'regulation': regulation,
-        'metabolism': metabolism,
-        'deriver': deriver}
+    processes = [
+        {'transport': transport,
+         'regulation': regulation,
+         'metabolism': metabolism},
+        {'deriver': deriver}]
 
     # initialize the states
     default_states = merge_default_states(processes)
@@ -32,7 +32,7 @@ def compose_covert2008(config):
     # get environment ids, and make exchange_ids for external state
     environment_ids = []
     initial_exchanges = {}
-    for process_id, process in processes.iteritems():
+    for process_id, process in merge_dicts(processes).iteritems():
         roles = {role: {} for role in process.roles.keys()}
         initial_exchanges.update(roles)
 

--- a/lens/composites/Covert2008_iFBA.py
+++ b/lens/composites/Covert2008_iFBA.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge, merge_dicts
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
+from lens.utils.dict_utils import merge_dicts
 
 # processes
 from lens.processes.CovertPalsson2002_metabolism import Covert2002Metabolism

--- a/lens/composites/growth_division.py
+++ b/lens/composites/growth_division.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import random
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge, merge_dicts
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
+from lens.utils.dict_utils import merge_dicts
 
 # processes
 from lens.processes.derive_volume import DeriveVolume

--- a/lens/composites/growth_division.py
+++ b/lens/composites/growth_division.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import random
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge, merge_dicts
 
 # processes
 from lens.processes.derive_volume import DeriveVolume
@@ -42,12 +42,11 @@ def compose_growth_division(config):
     division = Division(config)
     expression = ProteinExpression(config)
     deriver = DeriveVolume(config)
-    processes = {
-        'growth': growth,
-        'division': division,
-        'expression': expression,
-        'deriver': deriver,
-    }
+    processes = [
+        {'growth': growth,
+         'division': division,
+         'expression': expression},
+        {'deriver': deriver}]
 
     # configure the states to the roles for each process
     topology = {
@@ -70,7 +69,7 @@ def compose_growth_division(config):
     # get environment ids, and make exchange_ids for external state
     environment_ids = []
     initial_exchanges = {}
-    for process_id, process in processes.iteritems():
+    for process_id, process in merge_dicts(processes).iteritems():
         roles = {role: {} for role in process.roles.keys()}
         initial_exchanges.update(roles)
 

--- a/lens/composites/growth_division.py
+++ b/lens/composites/growth_division.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import random
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, dict_merge
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
 
 # processes
 from lens.processes.derive_volume import DeriveVolume
@@ -82,7 +82,7 @@ def compose_growth_division(config):
 
     states = {
         compartment_roles[role]: State(
-            initial_state=dict_merge(
+            initial_state=deep_merge(
                 default_states.get(role, {}),
                 dict(initial_state.get(compartment_roles[role], {}))),
             updaters=default_updaters.get(role, {}))

--- a/lens/environment/lattice_compartment.py
+++ b/lens/environment/lattice_compartment.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import uuid
 
-from lens.actor.process import Compartment, State, dict_merge
+from lens.actor.process import Compartment, State, deep_merge
 from lens.actor.emitter import get_emitter
 from lens.actor.inner import Simulation
 
@@ -136,11 +136,11 @@ def generate_lattice_compartment(process, config):
                 environment_ids.append(state_id)
                 initial_exchanges[role].update({state_id + exchange_key: 0.0})
 
-    default_states = dict_merge(default_states, initial_exchanges)
+    default_states = deep_merge(default_states, initial_exchanges)
 
     states = {
         role: State(
-            initial_state=dict_merge(
+            initial_state=deep_merge(
                 default_states.get(role, {}),
                 dict(initial_state.get(role, {}))),
             updaters=default_updaters.get(role, {}))

--- a/lens/processes/CovertPalsson2002_metabolism.py
+++ b/lens/processes/CovertPalsson2002_metabolism.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-from lens.actor.process import dict_merge
+from lens.actor.process import deep_merge
 from lens.data.spreadsheets import load_tsv
 from lens.data.helper import get_mols_from_stoich, get_mols_from_reg_logic
 

--- a/lens/processes/CovertPalsson2002_regulation.py
+++ b/lens/processes/CovertPalsson2002_regulation.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import csv
 
-from lens.actor.process import Process, dict_merge
+from lens.actor.process import Process, deep_merge
 from lens.data.spreadsheets import load_tsv
 from lens.data.helper import get_mols_from_reg_logic
 import lens.utils.regulation_logic as rl
@@ -56,7 +56,7 @@ class Regulation(Process):
         # TODO -- which states should be boolean?
         internal_molecules = {key: 0 for key in self.internal}
         external_molecules = {key: 0 for key in self.external}
-        internal = dict_merge(internal_molecules, {'volume': 1})
+        internal = deep_merge(internal_molecules, {'volume': 1})
 
         return {
             'external': external_molecules,
@@ -83,7 +83,7 @@ class Regulation(Process):
     def next_update(self, timestep, states):
         internal_state = states['internal']
         external_state = add_str_to_keys(states['external'], self.external_key)
-        total_state = dict_merge(internal_state, external_state)
+        total_state = deep_merge(internal_state, external_state)
         boolean_state = {mol_id: (value>0) for mol_id, value in total_state.iteritems()}
 
         regulatory_state = {mol_id: regulatory_logic(boolean_state)

--- a/lens/processes/Kremling2007_transport.py
+++ b/lens/processes/Kremling2007_transport.py
@@ -7,6 +7,8 @@ from scipy.integrate import odeint
 from lens.actor.process import Process
 from lens.utils.flux_conversion import millimolar_to_counts, counts_to_millimolar
 from lens.environment.make_media import Media
+from lens.utils.dict_utils import merge_dicts
+
 
 DEFAULT_PARAMETERS = {
     # enzyme synthesis
@@ -74,11 +76,6 @@ MOLECULAR_WEIGHTS = {
     'GLC': 180.16,
 }
 
-
-def merge_dicts(x, y):
-    z = x.copy()   # start with x's keys and values
-    z.update(y)    # modifies z with y's keys and values & returns None
-    return z
 
 
 class Transport(Process):

--- a/lens/processes/Vladimirov2008_motor.py
+++ b/lens/processes/Vladimirov2008_motor.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import random
 
-from lens.actor.process import Process, dict_merge
+from lens.actor.process import Process, deep_merge
 
 
 TUMBLE_JITTER = 1.0  # (radians)
@@ -73,7 +73,7 @@ class MotorActivity(Process):
         internal = INITIAL_STATE
         return {
             'external': {},
-            'internal': dict_merge(internal, {'volume': 1})}
+            'internal': deep_merge(internal, {'volume': 1})}
 
     def default_emitter_keys(self):
         keys = {

--- a/lens/processes/membrane_potential.py
+++ b/lens/processes/membrane_potential.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import scipy.constants as constants
 
-from lens.actor.process import Process, dict_merge
+from lens.actor.process import Process, deep_merge
 from lens.utils.units import units
 
 # (mmol) http://book.bionumbers.org/what-are-the-concentrations-of-different-ions-in-cells/
@@ -74,7 +74,7 @@ class MembranePotential(Process):
 
     def default_state(self):
         config = {'external': {'T': 310.15}}
-        default_state = dict_merge((self.initial_states), config)
+        default_state = deep_merge((self.initial_states), config)
         return default_state
 
     def default_emitter_keys(self):

--- a/lens/processes/metabolism.py
+++ b/lens/processes/metabolism.py
@@ -4,7 +4,7 @@ import os
 from scipy import constants
 import numpy as np
 
-from lens.actor.process import Process, dict_merge
+from lens.actor.process import Process, deep_merge
 from lens.utils.units import units
 from lens.utils.modular_fba import FluxBalanceAnalysis
 from lens.environment.lattice_compartment import add_str_in_list, remove_str_in_list, add_str_to_keys
@@ -90,7 +90,7 @@ class Metabolism(Process):
         internal.update(flux_targets)
         return {
             'external':  self.initial_state.get('external'),
-            'internal': dict_merge(dict(internal), self.initial_state.get('internal'))}
+            'internal': deep_merge(dict(internal), self.initial_state.get('internal'))}
 
     def default_emitter_keys(self):
         keys = {
@@ -126,7 +126,7 @@ class Metabolism(Process):
 
         ## Regulation
         # get the regulatory state of the reactions TODO -- are reversible reactions regulated?
-        total_state = dict_merge(dict(internal_state), external_state)
+        total_state = deep_merge(dict(internal_state), external_state)
         boolean_state = {mol_id: (value>1e-5) for mol_id, value in total_state.iteritems()}  # TODO -- generalize the threshold
         regulatory_state = {rxn_id: regulatory_logic(boolean_state)
                             for rxn_id, regulatory_logic in self.regulation.iteritems()}
@@ -175,7 +175,7 @@ class Metabolism(Process):
         rxn_dict = dict(zip(rxn_ids, rxn_fluxes))
 
         update = {
-            'internal': dict_merge(dict(new_mass), rxn_dict),
+            'internal': deep_merge(dict(new_mass), rxn_dict),
             'external': environment_deltas}
         return update
 

--- a/lens/utils/dict_utils.py
+++ b/lens/utils/dict_utils.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, division, print_function
+
+
+def merge_dicts(dicts):
+    merge = {}
+    for d in dicts:
+        merge.update(d)
+    return merge


### PR DESCRIPTION
Before we were emulating each process as happening simultaneously, with a special kind of process called a "deriver" happening after the other processes. In exploring the problem further, we found instances where we wanted an ordering of things, but for the rest of the processes they can still run with emulated simultaneity. This PR allows us to encode processes as a list of dicts, rather than one dict, which simplifies the process/deriver dichotomy and provides the option during composition to present a series of simultaneous processes, of which derivers need no longer be a special case. This also allows for things like an optimization layer to act on the state changes of the other processes. 

In the meantime I changed the function `dict_merge` to `deep_merge` as this more reflects its intention, and removes ambiguity or confusion with the new function `merge_dicts`, which merges a list of dicts into a single dict. 

@eagmon I updated the composites but did not test them as there are not yet tests in those files? We can talk about this, but we should probably add tests for all of the processes including composites so we can make framework changes like this with confidence.

All feedback welcome!