### PR TITLE
Towards swarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ runFitter manual runscript. In the wcEcoli directory:
 
    2. Open a browser window onto [http://localhost:33332](http://localhost:33332)
 
+
+## mongoDB
+    
+4. Run mongoDB. Homebrew installation: [homebrew.](https://github.com/mongodb/homebrew-brew) Docs: [mongoDB docs.](https://docs.mongodb.com/manual/mongo/#start-the-mongo-shell-and-connect-to-mongodb)
+    1. Run mongod as a service. To have launched start mongodb/brew/mongodb-community now and restart at login:
+    
+      `> brew services start mongodb/brew/mongodb-community`
+
+    2. Start mongod manually. Alternatively, if you don't want a background service you can just run:
+    
+      `> mongod --config /usr/local/etc/mongod.conf`
+
+
 ## One Agent Per Terminal Tab (esp. for debugging)
 
 **Note:** This section describes how to launch Environment and Cell agent processes directly

--- a/lens/actor/emitter.py
+++ b/lens/actor/emitter.py
@@ -45,7 +45,7 @@ def get_emitter(config):
 
     return {
         'object': emitter,
-        'keys': config.get('keys')}
+        'keys': config.get('keys',{})}
 
 def get_emitter_keys(process, topology):
     emitter_keys = {}

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -229,6 +229,7 @@ class Process(object):
 def connect_topology(process_layers, states, topology):
     ''' Given a set of processes and states, and a description of the connections
         between them, link the roles in each process to the state they refer to.'''
+
     for processes in process_layers:
         for name, process in processes.items():
             connections = topology[name]

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -302,8 +302,13 @@ class Compartment(object):
         self.divide_state = configuration.get('divide_state', default_divide_state)
 
         # emitter
-        self.emitter_keys = configuration['emitter'].get('keys')
-        self.emitter = configuration['emitter'].get('object')
+        if configuration.get('emitter'):
+            self.emitter_keys = configuration['emitter'].get('keys')
+            self.emitter = configuration['emitter'].get('object')
+        else:
+            emitter = emit.get_emitter({})
+            self.emitter_keys = emitter.get('keys')
+            self.emitter = emitter.get('object')
 
         connect_topology(processes, self.states, self.topology)
 

--- a/lens/actor/process.py
+++ b/lens/actor/process.py
@@ -140,7 +140,8 @@ class State(object):
                 value)
 
             for other_key, other_value in other_updates.items():
-                other_index = self.index_for(other_key)
+                # one key at a time
+                other_index = self.index_for([other_key])
                 self.new_state[other_index] = other_value
 
     def apply_updates(self, updates):
@@ -228,7 +229,6 @@ class Process(object):
 def connect_topology(process_layers, states, topology):
     ''' Given a set of processes and states, and a description of the connections
         between them, link the roles in each process to the state they refer to.'''
-
     for processes in process_layers:
         for name, process in processes.items():
             connections = topology[name]

--- a/lens/analysis/run_analysis.py
+++ b/lens/analysis/run_analysis.py
@@ -9,6 +9,7 @@ from lens.analysis.multigen_compartment import MultigenCompartment
 from lens.analysis.location_trace import LatticeTrace
 from lens.analysis.chemotaxis_trace import ChemotaxisTrace
 from lens.analysis.snapshots import Snapshots
+from lens.analysis.topology import Topology
 
 
 # classes for run_analysis to cycle through
@@ -18,6 +19,7 @@ analysis_classes = {
     'multigen': MultigenCompartment,
     'location': LatticeTrace,
     'snapshots': Snapshots,
+    'topology': Topology,
 }
 
 # mongoDB local url
@@ -131,8 +133,12 @@ class Analyze(object):
 
             if all(processes in active_processes for processes in required_processes):
 
-                # run the compartment analysis for each simulation in simulation_ids
-                if analysis.analysis_type is 'compartment':
+                if analysis.analysis_type is 'experiment':
+                    environment_data = analysis.get_data(history_client, query.copy())
+                    analysis.analyze(experiment_config, environment_data, output_dir)
+
+                elif analysis.analysis_type is 'compartment':
+                    # Run the compartment analysis for each simulation in simulation_ids
                     # A compartment analysis is run on a single compartment.
                     # It expects to run queries on the compartment tables in the DB.
                     # Output is saved to the compartment's directory.

--- a/lens/analysis/snapshots.py
+++ b/lens/analysis/snapshots.py
@@ -9,7 +9,7 @@ from lens.analysis.analysis import Analysis, get_compartment
 from lens.actor.process import deep_merge
 
 # DEFAULT_COLOR = [color/255 for color in [102, 178, 255]]
-DEFAULT_COLOR = [220/360, 100.0/100.0, 50.0/100.0]  # HSV
+DEFAULT_COLOR = [220/360, 100.0/100.0, 70.0/100.0]  # HSV
 FLOURESCENT_COLOR = [120/360, 100.0/100.0, 100.0/100.0]  # HSV
 
 # TODO (Eran) -- min/max should be an argument
@@ -137,8 +137,8 @@ class Snapshots(Analysis):
                     ax.set_yticklabels([])
                     ax.set_xticklabels([])
 
-                    # rotate field and plot
-                    field = np.rot90(np.array(field_data[field_id])).tolist()
+                    # transpose field to align with agent
+                    field = np.transpose(np.array(field_data[field_id])).tolist()
                     plt.imshow(field,
                                origin='lower',
                                extent=[0, edge_length_x, 0, edge_length_y],
@@ -185,7 +185,7 @@ class Snapshots(Analysis):
             rgb = hsv_to_rgb(agent_color)
 
             # Create a rectangle
-            rect = patches.Rectangle((x, y), width, length, theta, linewidth=1, edgecolor='k', facecolor=rgb)
+            rect = patches.Rectangle((x, y), width, length, theta, linewidth=1, edgecolor='w', facecolor=rgb)
             ax.add_patch(rect)
 
 

--- a/lens/analysis/snapshots.py
+++ b/lens/analysis/snapshots.py
@@ -112,7 +112,7 @@ class Snapshots(Analysis):
 
         # make figure
         fig = plt.figure(figsize=(20*n_snapshots, 10*n_fields))
-        grid = plt.GridSpec(n_fields, n_snapshots, wspace=0.2, hspace=0.01)
+        grid = plt.GridSpec(n_fields, n_snapshots, wspace=0.2, hspace=0.2)
         plt.rcParams.update({'font.size': 36})
         for index, time in enumerate(snapshot_times, 0):
             field_data = time_data[time].get('fields')

--- a/lens/analysis/topology.py
+++ b/lens/analysis/topology.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from lens.analysis.analysis import Analysis
+
+class Topology(Analysis):
+    def __init__(self):
+        super(Topology, self).__init__(analysis_type='experiment')
+
+    def get_data(self, client, query):
+        return
+
+    def analyze(self, experiment_config, history_data, output_dir):
+        topology = experiment_config['topology']
+
+        # save topology
+        json_out = json.dumps(topology)
+        f = open(output_dir + '/topology.json', 'w')
+        f.write(json_out)
+        f.close()

--- a/lens/composites/PMF_chemotaxis.py
+++ b/lens/composites/PMF_chemotaxis.py
@@ -1,27 +1,65 @@
 from __future__ import absolute_import, division, print_function
 
-from lens.actor.process import State, merge_default_states, merge_default_updaters, dict_merge
+import random
+
+from lens.actor.process import State, merge_default_states, merge_default_updaters, deep_merge
+from lens.utils.dict_utils import merge_dicts
 
 # processes
 from lens.processes.Endres2006_chemoreceptor import ReceptorCluster
 from lens.processes.Vladimirov2008_motor import MotorActivity
-from lens.processes.membrane_potential import MembranePotential
+# from lens.processes.membrane_potential import MembranePotential
+from lens.processes.Kremling2007_transport import Transport
+from lens.processes.derive_volume import DeriveVolume
+from lens.processes.division import Division
+
+
+def divide_condition(compartment):
+    division = compartment.states['cell'].state_for(['division'])
+    if division.get('division', 0) == 0:  # 0 is false
+        divide = False
+    else:
+        divide = True
+    return divide
+
+def divide_state(compartment):
+    divided = [{}, {}]
+    for state_key, state in compartment.states.items():
+        left = random.randint(0, 1)
+        for index in range(2):
+            divided[index][state_key] = {}
+            for key, value in state.to_dict().items():
+                if key == 'division':
+                    divided[index][state_key][key] = 0
+                else:
+                    divided[index][state_key][key] = value // 2 + (value % 2 if index == left else 0)
+
+    print('divided {}'.format(divided))
+    return divided
 
 
 def compose_pmf_chemotaxis(config):
     exchange_key = config.get('exchange_key')
+    receptor_parameters = {'ligand': 'GLC'}
+    receptor_parameters.update(config)
 
     # declare the processes
-    receptor = ReceptorCluster(config)
-    motor = MotorActivity(config)
-    PMF = MembranePotential(config)
     # TODO -- add flagella process.  for now assume fixed flagella.
+    receptor = ReceptorCluster(receptor_parameters)
+    motor = MotorActivity(config)
+    # PMF = MembranePotential(config)
+    transport = Transport(config)
+    deriver = DeriveVolume(config)
+    division = Division(config)
 
-    processes = {
-        'receptor': receptor,
-        'motor': motor,
-        'PMF': PMF,
-    }
+    processes = [
+        # {'PMF': PMF},
+        {'receptor': receptor,
+         'transport': transport},
+        {'motor': motor},
+        {'deriver': deriver,
+         'division': division},
+    ]
 
     # initialize the states
     default_states = merge_default_states(processes)
@@ -32,27 +70,27 @@ def compose_pmf_chemotaxis(config):
     # get environment ids, and make exchange_ids for external state
     environment_ids = []
     initial_exchanges = {}
-    for process_id, process in processes.iteritems():
+    for process_id, process in merge_dicts(processes).items():
         roles = {role: {} for role in process.roles.keys()}
         initial_exchanges.update(roles)
 
-    for role, state_ids in default_updaters.iteritems():
-        for state_id, updater in state_ids.iteritems():
+    for role, state_ids in default_updaters.items():
+        for state_id, updater in state_ids.items():
             if updater is 'accumulate':
                 environment_ids.append(state_id)
                 initial_exchanges[role].update({state_id + exchange_key: 0.0})
 
-    default_states = dict_merge(default_states, initial_exchanges)
+    default_states = deep_merge(default_states, initial_exchanges)
 
     # set states according to the compartment_roles mapping.
     # This will not generalize to composites with processes that have different roles
     compartment_roles = {
         'external': 'environment',
-        'internal': 'cytoplasm'}
+        'internal': 'cell'}
 
     states = {
         compartment_roles[role]: State(
-            initial_state=dict_merge(
+            initial_state=deep_merge(
                 default_states.get(role, {}),
                 dict(initial_state.get(compartment_roles[role], {}))),
             updaters=default_updaters.get(role, {}))
@@ -62,22 +100,27 @@ def compose_pmf_chemotaxis(config):
     topology = {
         'receptor': {
             'external': 'environment',
-            'internal': 'cytoplasm'},
+            'internal': 'cell'},
+        'transport': {
+            'external': 'environment',
+            'internal': 'cell'},
         'motor': {
             'external': 'environment',
-            'internal': 'cytoplasm'},
-        'PMF': {
-            'external': 'environment',
-            'membrane': 'membrane',
-            'internal': 'cytoplasm'},
+            'internal': 'cell'},
+        'deriver': {
+            'internal': 'cell'},
+        'division': {
+            'internal': 'cell'},
         }
 
     options = {
         'topology': topology,
-		'initial_time': initial_time,
+        'initial_time': initial_time,
         'environment': 'environment',
-        'compartment': 'cytoplasm',   # TODO -- should this include both cytoplasm and membrane?
+        'compartment': 'cell',
         'environment_ids': environment_ids,
+        'divide_condition': divide_condition,
+        'divide_state': divide_state
     }
 
     return {

--- a/lens/composites/PMF_chemotaxis.py
+++ b/lens/composites/PMF_chemotaxis.py
@@ -15,6 +15,7 @@ def compose_pmf_chemotaxis(config):
     receptor = ReceptorCluster(config)
     motor = MotorActivity(config)
     PMF = MembranePotential(config)
+    # TODO -- add flagella process.  for now assume fixed flagella.
 
     processes = {
         'receptor': receptor,
@@ -75,7 +76,7 @@ def compose_pmf_chemotaxis(config):
         'topology': topology,
 		'initial_time': initial_time,
         'environment': 'environment',
-        'compartment': 'cell',   # TODO -- does this include cytoplasm and membrane?
+        'compartment': 'cytoplasm',   # TODO -- should this include both cytoplasm and membrane?
         'environment_ids': environment_ids,
     }
 

--- a/lens/composites/PMF_chemotaxis.py
+++ b/lens/composites/PMF_chemotaxis.py
@@ -5,20 +5,21 @@ from lens.actor.process import State, merge_default_states, merge_default_update
 # processes
 from lens.processes.Endres2006_chemoreceptor import ReceptorCluster
 from lens.processes.Vladimirov2008_motor import MotorActivity
-from lens.processes.derive_volume import DeriveVolume
+from lens.processes.membrane_potential import MembranePotential
 
 
-def compose_chemotaxis(config):
+def compose_pmf_chemotaxis(config):
     exchange_key = config.get('exchange_key')
 
     # declare the processes
     receptor = ReceptorCluster(config)
     motor = MotorActivity(config)
-    # deriver = DeriveVolume(config)
+    PMF = MembranePotential(config)
+
     processes = {
         'receptor': receptor,
         'motor': motor,
-        # 'deriver': deriver
+        'PMF': PMF,
     }
 
     # initialize the states
@@ -46,7 +47,7 @@ def compose_chemotaxis(config):
     # This will not generalize to composites with processes that have different roles
     compartment_roles = {
         'external': 'environment',
-        'internal': 'cell'}
+        'internal': 'cytoplasm'}
 
     states = {
         compartment_roles[role]: State(
@@ -60,19 +61,21 @@ def compose_chemotaxis(config):
     topology = {
         'receptor': {
             'external': 'environment',
-            'internal': 'cell'},
+            'internal': 'cytoplasm'},
         'motor': {
             'external': 'environment',
-            'internal': 'cell'},
-        # 'deriver': {
-        #     'internal': 'cell'},
+            'internal': 'cytoplasm'},
+        'PMF': {
+            'external': 'environment',
+            'membrane': 'membrane',
+            'internal': 'cytoplasm'},
         }
 
     options = {
         'topology': topology,
 		'initial_time': initial_time,
         'environment': 'environment',
-        'compartment': 'cell',
+        'compartment': 'cell',   # TODO -- does this include cytoplasm and membrane?
         'environment_ids': environment_ids,
     }
 

--- a/lens/composites/Vladimirov2008_chemotaxis.py
+++ b/lens/composites/Vladimirov2008_chemotaxis.py
@@ -1,0 +1,77 @@
+from __future__ import absolute_import, division, print_function
+
+from lens.actor.process import State, merge_default_states, merge_default_updaters, dict_merge
+
+# processes
+from lens.processes.Endres2006_chemoreceptor import ReceptorCluster
+from lens.processes.Vladimirov2008_motor import MotorActivity
+
+
+def compose_vladimirov_chemotaxis(config):
+    exchange_key = config.get('exchange_key')
+
+    # declare the processes
+    receptor = ReceptorCluster(config)
+    motor = MotorActivity(config)
+    processes = {
+        'receptor': receptor,
+        'motor': motor,
+    }
+
+    # initialize the states
+    default_states = merge_default_states(processes)
+    default_updaters = merge_default_updaters(processes)
+    initial_state = config.get('initial_state', {})
+    initial_time = config.get('initial_time', 0.0)
+
+    # get environment ids, and make exchange_ids for external state
+    environment_ids = []
+    initial_exchanges = {}
+    for process_id, process in processes.iteritems():
+        roles = {role: {} for role in process.roles.keys()}
+        initial_exchanges.update(roles)
+
+    for role, state_ids in default_updaters.iteritems():
+        for state_id, updater in state_ids.iteritems():
+            if updater is 'accumulate':
+                environment_ids.append(state_id)
+                initial_exchanges[role].update({state_id + exchange_key: 0.0})
+
+    default_states = dict_merge(default_states, initial_exchanges)
+
+    # set states according to the compartment_roles mapping.
+    # This will not generalize to composites with processes that have different roles
+    compartment_roles = {
+        'external': 'environment',
+        'internal': 'cell'}
+
+    states = {
+        compartment_roles[role]: State(
+            initial_state=dict_merge(
+                default_states.get(role, {}),
+                dict(initial_state.get(compartment_roles[role], {}))),
+            updaters=default_updaters.get(role, {}))
+        for role in default_states.keys()}
+
+    # configure the states to the roles for each process
+    topology = {
+        'receptor': {
+            'external': 'environment',
+            'internal': 'cell'},
+        'motor': {
+            'external': 'environment',
+            'internal': 'cell'},
+        }
+
+    options = {
+        'topology': topology,
+		'initial_time': initial_time,
+        'environment': 'environment',
+        'compartment': 'cell',
+        'environment_ids': environment_ids,
+    }
+
+    return {
+        'processes': processes,
+        'states': states,
+        'options': options}

--- a/lens/composites/Vladimirov2008_chemotaxis.py
+++ b/lens/composites/Vladimirov2008_chemotaxis.py
@@ -14,10 +14,9 @@ def compose_vladimirov_chemotaxis(config):
     # declare the processes
     receptor = ReceptorCluster(config)
     motor = MotorActivity(config)
-    processes = [{
-        'receptor': receptor,
-        'motor': motor,
-    }]
+    processes = [
+        {'receptor': receptor},
+        {'motor': motor}]
 
     # initialize the states
     default_states = merge_default_states(processes)

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -270,7 +270,7 @@ def initialize_measp(agent_config):
         'run_for': 1.0,
         'static_concentrations': True,
         'gradient': {
-            'seed': True,
+            'type': 'gaussian',
             'molecules': {
                 'GLC': {
                     'center': [0.5, 0.5],
@@ -300,14 +300,14 @@ def initialize_measp_long(agent_config):
         'run_for': 1.0,
         'static_concentrations': True,
         'gradient': {
-            'seed': True,
+            'type': 'linear',
             'molecules': {
                 'GLC': {
-                    'center': [0.25, 0.5],
-                    'deviation': 30.0},
+                    'center': [0.0, 0.0],
+                    'slope': -1.0/150.0},
                 'MeAsp': {
-                    'center': [0.75, 0.5],
-                    'deviation': 30.0}
+                    'center': [1.0, 1.0],
+                    'slope': -1.0/150.0}
             }},
         'diffusion': 0.0,
         'rotation_jitter': 0.005,
@@ -331,7 +331,7 @@ def initialize_measp_large(agent_config):
         'run_for': 1.0,
         'static_concentrations': True,
         'gradient': {
-            'seed': True,
+            'type': 'gaussian',
             'molecules': {
                 'GLC': {
                     'center': [0.5, 0.5],

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -30,6 +30,8 @@ from lens.actor.emitter import get_emitter, configure_emitter
 # environment
 from lens.environment.lattice import EnvironmentSpatialLattice
 from lens.environment.lattice_compartment import LatticeCompartment, generate_lattice_compartment
+from lens.environment.make_media import Media
+from lens.utils.units import units
 
 # processes
 from lens.processes.transport_lookup import TransportLookup
@@ -320,30 +322,42 @@ def initialize_measp_long(agent_config):
 
 
 def initialize_measp_large(agent_config):
-    media_id = 'MeAsp_media'
-    media = {'GLC': 20.0,  # assumes mmol/L
-             'MeAsp': 1.0}
+    # media_id = 'MeAsp_media'
+    # media = {'GLC': 20.0,  # assumes mmol/L
+    #          'MeAsp': 1.0}
+    # new_media = {media_id: media}
+    # timeline_str = '0 {}, 3600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
+
+    ## Make media: GLC_G6P with MeAsp
+    # get GLC_G6P media
+    make_media = Media()
+    media1 = make_media.get_saved_media('GLC_G6P', True)
+
+    # make MeAsp media
+    ingredients = {
+        'MeAsp': {
+            'counts': 1.0 * units.mmol,
+            'volume': 0.001 * units.L}}
+    media2 = make_media.make_recipe(ingredients, True)
+
+    # combine the medias
+    media = make_media.combine_media(media1, 0.999 * units.L, media2, 0.001 * units.L)
+    media_id = 'GLC_G6P_MeAsp'
+
+    # make timeline with new media
     new_media = {media_id: media}
-    timeline_str = '0 {}, 3600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
+    timeline_str = '0 {}, 3600 end'.format(media_id)
+
     boot_config = {
         'timeline_str': timeline_str,
         'new_media': new_media,
         'run_for': 1.0,
-        'static_concentrations': True,
-        'gradient': {
-            'type': 'gaussian',
-            'molecules': {
-                'GLC': {
-                    'center': [0.5, 0.5],
-                    'deviation': 30.0},
-                'MeAsp': {
-                    'center': [0.5, 0.5],
-                    'deviation': 30.0}
-            }},
-        'diffusion': 0.0,
+        'cell_placement': [0.5, 0.5],  # place cells at center of lattice
+        'emit_fields': ['GLC', 'MeAsp'],
+        'diffusion': 0.001,
         'rotation_jitter': 0.005,
         'edge_length_x': 200.0,
-        'patches_per_edge_x': 40}
+        'patches_per_edge_x': 50}
     boot_config.update(agent_config)
 
     return boot_config

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -400,8 +400,8 @@ class BootEnvironment(BootAgent):
             'growth_division': wrap_boot(wrap_init_composite(compose_growth_division), {'volume': 1.0}),
             'covert2002': wrap_boot(wrap_init_composite(compose_covert2002), {'volume': 1.0}),
             'covert2008': wrap_boot(wrap_init_composite(compose_covert2008), {'volume': 1.0}),
-            'chemotaxis': wrap_boot(wrap_init_composite(compose_vladimirov_chemotaxis), {'volume': 1.0})
-            'pmf_chemotaxis': wrap_boot(wrap_init_composite(compose_pmf_chemotaxis), {'volume': 1.0})
+            'chemotaxis': wrap_boot(wrap_init_composite(compose_vladimirov_chemotaxis), {'volume': 1.0}),
+            'pmf_chemotaxis': wrap_boot(wrap_init_composite(compose_pmf_chemotaxis), {'volume': 1.0}),
             }
 
 def run():

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -44,7 +44,8 @@ from lens.processes.membrane_potential import MembranePotential
 from lens.composites.Covert2002_rFBA import compose_covert2002
 from lens.composites.Covert2008_iFBA import compose_covert2008
 from lens.composites.growth_division import compose_growth_division
-from lens.composites.Chemotaxis import compose_chemotaxis
+from lens.composites.Vladimirov2008_chemotaxis import compose_vladimirov_chemotaxis
+from lens.composites.PMF_chemotaxis import compose_pmf_chemotaxis
 
 
 DEFAULT_COLOR = [0.6, 0.4, 0.3]
@@ -399,7 +400,8 @@ class BootEnvironment(BootAgent):
             'growth_division': wrap_boot(wrap_init_composite(compose_growth_division), {'volume': 1.0}),
             'covert2002': wrap_boot(wrap_init_composite(compose_covert2002), {'volume': 1.0}),
             'covert2008': wrap_boot(wrap_init_composite(compose_covert2008), {'volume': 1.0}),
-            'chemotaxis': wrap_boot(wrap_init_composite(compose_chemotaxis), {'volume': 1.0})
+            'chemotaxis': wrap_boot(wrap_init_composite(compose_vladimirov_chemotaxis), {'volume': 1.0})
+            'pmf_chemotaxis': wrap_boot(wrap_init_composite(compose_pmf_chemotaxis), {'volume': 1.0})
             }
 
 def run():

--- a/lens/environment/boot.py
+++ b/lens/environment/boot.py
@@ -26,6 +26,8 @@ from lens.actor.inner import Inner
 from lens.actor.outer import Outer
 from lens.actor.boot import BootAgent
 from lens.actor.emitter import get_emitter, configure_emitter
+
+# environment
 from lens.environment.lattice import EnvironmentSpatialLattice
 from lens.environment.lattice_compartment import LatticeCompartment, generate_lattice_compartment
 

--- a/lens/environment/control.py
+++ b/lens/environment/control.py
@@ -205,7 +205,8 @@ class ShepherdControl(ActorControl):
         media = {'GLC': 20.0,
                  'MeAsp': 1.0}
         new_media = {media_id: media}
-        timeline_str = '0 {}, 14400 end'.format(media_id)
+        # timeline_str = '0 {}, 14400 end'.format(media_id)
+        timeline_str = '0 {}, 7200 end'.format(media_id)
 
         chemotaxis_config = {
             'timeline_str': timeline_str,
@@ -214,14 +215,14 @@ class ShepherdControl(ActorControl):
             'emit_fields': ['MeAsp', 'GLC'],
             'static_concentrations': True,
             'gradient': {
-                'seed': True,
+                'type': 'linear',
                 'molecules': {
                     'GLC':{
-                        'center': [0.75, 0.5],
-                        'deviation': 30.0},
+                        'center': [0.0, 0.0],
+                        'slope': -1.0/150.0},
                     'MeAsp': {
-                        'center': [0.25, 0.5],
-                        'deviation': 30.0}
+                        'center': [1.0, 1.0],
+                        'slope': -1.0/150.0}
                 }},
             'diffusion': 0.0,
             # 'translation_jitter': 0.1,

--- a/lens/environment/control.py
+++ b/lens/environment/control.py
@@ -4,6 +4,8 @@ import time
 import uuid
 
 from lens.actor.control import ActorControl, AgentCommand
+from lens.environment.make_media import Media
+from lens.utils.units import units
 
 
 class ShepherdControl(ActorControl):
@@ -247,9 +249,24 @@ class ShepherdControl(ActorControl):
         print('Creating lattice agent_id {} and {} cell agents\n'.format(
             experiment_id, num_cells))
 
-        media_id = 'MeAsp'
-        media = {'GLC': 20.0,
-                 'MeAsp': 1.0}
+        ## Make media: GLC_G6P with MeAsp
+        # get GLC_G6P media
+        make_media = Media()
+        media_id = 'GLC_G6P'
+        media1 = make_media.get_saved_media('GLC_G6P', True)
+
+        # make MeAsp media
+        ingredients = {
+            'MeAsp': {
+                'counts': 1.0 * units.mmol,
+                'volume': 0.001 * units.L}}
+        media2 = make_media.make_recipe(ingredients, True)
+
+        # combine the medias
+        media = make_media.combine_media(media1, 0.999 * units.L, media2, 0.001 * units.L)
+        media_id = 'GLC_G6P_MeAsp'
+
+        # make timeline with new media
         new_media = {media_id: media}
         timeline_str = '0 {}, 3600 end'.format(media_id)
 

--- a/lens/environment/lattice.py
+++ b/lens/environment/lattice.py
@@ -56,6 +56,7 @@ class EnvironmentSpatialLattice(EnvironmentSimulation):
         self.cell_radius = config.get('cell_radius', 0.5)  # TODO -- this should be a property of cells.
         self.translation_jitter = config.get('translation_jitter', TRANSLATION_JITTER)
         self.rotation_jitter = config.get('rotation_jitter', ROTATION_JITTER)
+        self.cell_placement = config.get('cell_placement')
 
         ## Lattice Parameters
         # if edge_length_y not provided, assume it is equal to edge_length_x.
@@ -334,6 +335,14 @@ class EnvironmentSpatialLattice(EnvironmentSimulation):
 
                 daughter_locations = self.daughter_locations(parent_location, parent_length, orientation)
                 location = daughter_locations[index]
+            elif self.cell_placement:
+                placement = np.array([
+                    self.cell_placement[0] * self.edge_length_x,
+                    self.cell_placement[1] * self.edge_length_y])
+                location = simulation['agent_config'].get(
+                    'location', placement)
+                orientation = simulation['agent_config'].get(
+                    'orientation', np.random.uniform(0, 2 * PI))
             else:
                 # Place cell at either the provided or a random initial location
                 random_location = np.array([

--- a/lens/environment/lattice_compartment.py
+++ b/lens/environment/lattice_compartment.py
@@ -60,7 +60,10 @@ class LatticeCompartment(Compartment, Simulation):
         self.last_update = update
         environment = self.states.get(self.environment)
         if environment:
-            environment.assign_values(update['concentrations'])
+            # update only the keys defined in environment
+            env_keys = environment.keys
+            local_environment = {key : update['concentrations'][key] for key in env_keys}
+            environment.assign_values(local_environment)
             environment.assign_values({key: 0 for key in self.exchange_ids})  # reset exchange
 
     def generate_daughters(self):

--- a/lens/environment/lattice_compartment.py
+++ b/lens/environment/lattice_compartment.py
@@ -60,9 +60,11 @@ class LatticeCompartment(Compartment, Simulation):
         self.last_update = update
         environment = self.states.get(self.environment)
         if environment:
-            # update only the keys defined in environment
-            env_keys = environment.keys
-            local_environment = {key : update['concentrations'][key] for key in env_keys}
+            # update only the keys defined in both compartment's environment and the external environment
+            local_env_keys = environment.keys
+            env_keys = update['concentrations'].keys()
+            local_environment = {key : update['concentrations'][key] for key in local_env_keys if key in env_keys}
+
             environment.assign_values(local_environment)
             environment.assign_values({key: 0 for key in self.exchange_ids})  # reset exchange
 
@@ -174,4 +176,5 @@ def generate_lattice_compartment(process, config):
     options.update(config['compartment_options'])
 
     # create the compartment
-    return LatticeCompartment(processes, states, options)
+    # processes go in a list to support process_layers
+    return LatticeCompartment([processes], states, options)

--- a/lens/processes/Endres2006_chemoreceptor.py
+++ b/lens/processes/Endres2006_chemoreceptor.py
@@ -40,8 +40,7 @@ DEFAULT_PARAMETERS = {
 class ReceptorCluster(Process):
     def __init__(self, initial_parameters={}):
 
-        self.ligand_id = LIGAND_ID
-
+        self.ligand_id = initial_parameters.get('ligand', LIGAND_ID)
         roles = {
             'internal': ['n_methyl', 'chemoreceptor_activity', 'CheR', 'CheB'],
             'external': [self.ligand_id]

--- a/lens/processes/Kremling2007_transport.py
+++ b/lens/processes/Kremling2007_transport.py
@@ -134,7 +134,7 @@ class Transport(Process):
 
         return {
             'external': external,
-            'internal': merge_dicts(internal, {'volume': 1})}  #TODO -- get volume with deriver?
+            'internal': merge_dicts([internal, {'volume': 1}])}  #TODO -- get volume with deriver?
 
     def default_emitter_keys(self):
         keys = {

--- a/lens/processes/Kremling2007_transport.py
+++ b/lens/processes/Kremling2007_transport.py
@@ -402,5 +402,3 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
     plot_transport(saved_state, out_dir)
-
-

--- a/lens/processes/derive_volume.py
+++ b/lens/processes/derive_volume.py
@@ -6,17 +6,17 @@ from lens.utils.units import units
 
 class DeriveVolume(Process):
     def __init__(self, initial_parameters={}):
-        self.density = 1100 #* units.g / units.L
+        parameters = {'density': 1100}  # * units.g / units.L
         roles = {
             'internal': ['mass', 'volume'],
         }
-        parameters = {}
+        parameters.update(initial_parameters)
 
-        super(DeriveVolume, self).__init__(roles, parameters, deriver=True)
+        super(DeriveVolume, self).__init__(roles, parameters)
 
     def default_state(self):
         mass = 1339 * units.fg  # 1.339e-12 g  # 1339 (wet mass in fg)
-        density = self.density * units.g / units.L
+        density = self.parameters['density'] * units.g / units.L
         volume = mass/density
 
         default_state = {
@@ -24,9 +24,7 @@ class DeriveVolume(Process):
             'volume': volume.to('fL').magnitude,
         }
 
-        return {
-            'internal': default_state,
-        }
+        return {'internal': default_state}
 
     def default_emitter_keys(self):
         keys = {'internal': ['mass', 'volume']}
@@ -34,7 +32,7 @@ class DeriveVolume(Process):
 
     def next_update(self, timestep, states):
         mass = states['internal']['mass'] * units.fg
-        density = self.density * units.g / units.L
+        density = self.parameters['density'] * units.g / units.L
         volume =  mass / density
         update = {'internal': {'volume': volume.to('fL').magnitude}}
 

--- a/lens/processes/membrane_potential.py
+++ b/lens/processes/membrane_potential.py
@@ -63,11 +63,15 @@ class MembranePotential(Process):
         self.permeability = config.get('permeability', PERMEABILITY_MAP)
         self.charge = config.get('charge', CHARGE_MAP)
 
+        # get list of internal and external states
+        internal_states = self.initial_states['internal'].keys()
+        external_states = self.initial_states['external'].keys()
+
         # set roles
         roles = {
-            'internal': ['c_in'],
+            'internal': internal_states + ['c_in'],
             'membrane': ['PMF', 'd_V', 'd_pH'],  # proton motive force (PMF), electrical difference (d_V), pH difference (d_pH)
-            'external': ['c_out'],
+            'external': external_states + ['c_out', 'T'],
         }
 
         super(MembranePotential, self).__init__(roles, parameters)

--- a/lens/processes/membrane_potential.py
+++ b/lens/processes/membrane_potential.py
@@ -218,23 +218,33 @@ def plot_mem_potential(saved_state, out_dir='out'):
     # plot data
     plot_idx = 0
     for key in data_keys:
-        for mol_id, series in sorted(saved_state[key].iteritems()):
+
+        if key in ['internal', 'external']:
             ax = fig.add_subplot(grid[plot_idx, 0])  # grid is (row, column)
+            for mol_id, series in sorted(saved_state[key].iteritems()):
+                # if mol_id is 'T':
+                #     pass
+                # else:
+                ax.plot(time_vec, series, label=mol_id)
 
-            ax.plot(time_vec, series)
-            ax.title.set_text(str(key) + ': ' + mol_id)
+            ax.title.set_text(key)
+            ax.set_yscale('log')
+            ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
             ax.set_xlabel('time (hrs)')
-
-            # if key is 'internal':
-            #     ax.set_yticks([0.0, 1.0])
-            #     ax.set_yticklabels(["False", "True"])
-
             plot_idx += 1
+
+        else:
+            for mol_id, series in sorted(saved_state[key].iteritems()):
+                ax = fig.add_subplot(grid[plot_idx, 0])  # grid is (row, column)
+                ax.plot(time_vec, series)
+                ax.title.set_text(str(key) + ': ' + mol_id)
+                ax.set_xlabel('time (hrs)')
+                plot_idx += 1
 
     # save figure
     fig_path = os.path.join(out_dir, 'membrane_potential')
     plt.subplots_adjust(wspace=0.5, hspace=0.5)
-    plt.savefig(fig_path + '.pdf', bbox_inches='tight')
+    plt.savefig(fig_path + '.png', bbox_inches='tight')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR moves the chemotaxis composite towards swarming behavior. There are several changes, including a couple bug fixes following the new implementation of process layers (#75).

Changes include:
- a ```PMF_chemotaxis``` composite with added ```transport```, ```volume_deriver```, ```division``` processes. This is a work in progress, and still requires PMF integration
- ```swarm_experiment``` in control. The goal is to place a few chemotactic cells in the center of the environment, and simulate their spread and the formation of chemotactic rings. This experiment creates a hybrid media that supports both transport and chemotaxis processes. A few new options for lattice were also required:
    - an option to place cells in lattice at exact locations (the center is used for swarm experiments):
![snapshots](https://user-images.githubusercontent.com/6809431/69082448-efea4780-09f4-11ea-830b-fea5b7febc60.png)
    - a linear gradient option for lattice:
![snapshots](https://user-images.githubusercontent.com/6809431/69081941-ed3b2280-09f3-11ea-879d-fbac787bae13.png)