### PR TITLE
Convenience kinetics process

### DIFF
--- a/lens/processes/convenience_kinetics.py
+++ b/lens/processes/convenience_kinetics.py
@@ -2,20 +2,19 @@ from __future__ import absolute_import, division, print_function
 
 from lens.actor.process import Process
 from lens.utils.kinetic_rate_laws import KineticFluxModel
-from lens.utils.units import units
 from lens.utils.dict_utils import merge_dicts
 
 
 class ConvenienceKinetics(Process):
 
     def __init__(self, initial_parameters={}):
-        reactions = initial_parameters.get('reactions')
+        self.reactions = initial_parameters.get('reactions')
         kinetic_parameters = initial_parameters.get('kinetic_parameters')
         roles = initial_parameters.get('roles')
         self.initial_state = initial_parameters.get('initial_state')
 
         # Make the kinetic model
-        self.kinetic_rate_laws = KineticFluxModel(reactions, kinetic_parameters)
+        self.kinetic_rate_laws = KineticFluxModel(self.reactions, kinetic_parameters)
 
         roles.update({'fluxes': self.kinetic_rate_laws.reaction_ids})
 
@@ -43,12 +42,26 @@ class ConvenienceKinetics(Process):
         return default_settings
 
     def next_update(self, timestep, states):
-        # TODO -- might need to distinguish different roles with suffixes,
+
+        # kinetic rate law requires a flat dict with states.
+        # TODO -- might need to distinguish different roles with suffixes (_external, _internal, etc)
         flattened_states = merge_dicts([role_states for role, role_states in states.items()])
 
+        # get flux
         fluxes = self.kinetic_rate_laws.get_fluxes(flattened_states)
 
-        return {'fluxes': fluxes}
+        # apply fluxes to state
+        update = {role: {} for role in self.roles.keys()}
+        update.update({'fluxes': fluxes})
+        for reaction_id, flux in fluxes.items():
+            stoichiometry = self.reactions[reaction_id]['stoichiometry']
+            for state_id, coeff in stoichiometry.items():
+                # which role is state_id in? TODO -- there must be a better way to do this.
+                for role_id, state_list in self.roles.items():
+                    if state_id in state_list:
+                        update[role_id][state_id] = coeff * flux
+
+        return update
 
 
 
@@ -66,16 +79,13 @@ toy_kinetics = {
     'reaction1': {
         'enzyme1': {
             'B': 0.1,
-            'kcat_f': 1.0}
+            'kcat_f': 0.1}
         }
     }
 
 toy_roles = {
-    'internal': [
-        'A',
-        'enzyme1'],
-    'external': [
-        'B']
+    'internal': ['A', 'enzyme1'],
+    'external': ['B'],
     }
 
 toy_initial_state = {
@@ -83,13 +93,13 @@ toy_initial_state = {
         'A': 1.0,
         'enzyme1': 1.0},
     'external': {
-        'B': 1.0}
+        'B': 1.0},
+    'fluxes': {
+        'reaction1': 0.0}
     }
-
 
 # test
 def test_convenience_kinetics():
-
     toy_config = {
         'reactions': toy_reactions,
         'kinetic_parameters': toy_kinetics,
@@ -102,8 +112,17 @@ def test_convenience_kinetics():
     settings = kinetic_process.default_settings()
     state = settings['state']
 
+    # run the simulation
     timestep = 1
-    update = kinetic_process.next_update(timestep, state)
+    for step in range(10):
+        # get update
+        update = kinetic_process.next_update(timestep, state)
+
+        # apply update
+        for role_id, states_update in update.items():
+            for state_id, change in states_update.items():
+                state[role_id][state_id] += change
+        print(state)
 
 
 if __name__ == '__main__':

--- a/lens/processes/convenience_kinetics.py
+++ b/lens/processes/convenience_kinetics.py
@@ -1,0 +1,110 @@
+from __future__ import absolute_import, division, print_function
+
+from lens.actor.process import Process
+from lens.utils.kinetic_rate_laws import KineticFluxModel
+from lens.utils.units import units
+from lens.utils.dict_utils import merge_dicts
+
+
+class ConvenienceKinetics(Process):
+
+    def __init__(self, initial_parameters={}):
+        reactions = initial_parameters.get('reactions')
+        kinetic_parameters = initial_parameters.get('kinetic_parameters')
+        roles = initial_parameters.get('roles')
+        self.initial_state = initial_parameters.get('initial_state')
+
+        # Make the kinetic model
+        self.kinetic_rate_laws = KineticFluxModel(reactions, kinetic_parameters)
+
+        roles.update({'fluxes': self.kinetic_rate_laws.reaction_ids})
+
+        parameters = {}
+        super(ConvenienceKinetics, self).__init__(roles, parameters)
+
+    def default_settings(self):
+
+        # default state
+        default_state = self.initial_state
+
+        # default emitter keys
+        default_emitter_keys = {}
+
+        # default updaters
+        default_updaters = {}
+
+        default_settings = {
+            'process_id': 'template',
+            'state': default_state,
+            'emitter_keys': default_emitter_keys,
+            'updaters': default_updaters,
+            'time_step': 1.0}
+
+        return default_settings
+
+    def next_update(self, timestep, states):
+        # TODO -- might need to distinguish different roles with suffixes,
+        flattened_states = merge_dicts([role_states for role, role_states in states.items()])
+
+        fluxes = self.kinetic_rate_laws.get_fluxes(flattened_states)
+
+        return {'fluxes': fluxes}
+
+
+
+# testing functions
+toy_reactions = {
+    'reaction1': {
+        'stoichiometry': {
+            'A': 1,
+            'B': -1},
+        'is reversible': False,
+        'catalyzed by': ['enzyme1']}
+    }
+
+toy_kinetics = {
+    'reaction1': {
+        'enzyme1': {
+            'B': 0.1,
+            'kcat_f': 1.0}
+        }
+    }
+
+toy_roles = {
+    'internal': [
+        'A',
+        'enzyme1'],
+    'external': [
+        'B']
+    }
+
+toy_initial_state = {
+    'internal': {
+        'A': 1.0,
+        'enzyme1': 1.0},
+    'external': {
+        'B': 1.0}
+    }
+
+
+# test
+def test_convenience_kinetics():
+
+    toy_config = {
+        'reactions': toy_reactions,
+        'kinetic_parameters': toy_kinetics,
+        'initial_state': toy_initial_state,
+        'roles': toy_roles}
+
+    kinetic_process = ConvenienceKinetics(toy_config)
+
+    # get initial state and parameters
+    settings = kinetic_process.default_settings()
+    state = settings['state']
+
+    timestep = 1
+    update = kinetic_process.next_update(timestep, state)
+
+
+if __name__ == '__main__':
+    test_convenience_kinetics()

--- a/lens/utils/kinetic_rate_laws.py
+++ b/lens/utils/kinetic_rate_laws.py
@@ -1,6 +1,7 @@
 '''
 Kinetic rate law generation using the Convenience Kinetics formulation of Michaelis-Menten kinetics
 
+# TODO -- make a vmax options if enzyme kcats not available
 '''
 
 from __future__ import absolute_import, division, print_function

--- a/lens/utils/kinetic_rate_laws.py
+++ b/lens/utils/kinetic_rate_laws.py
@@ -23,11 +23,11 @@ def make_configuration(reactions):
     rate_law_configuration = {}
     # gets all potential interactions between the reactions
     for reaction_id, specs in reactions.items():
-        transporters = specs['catalyzed by']
-        # initialize all transporters' entries
-        for transporter in transporters:
-            if transporter not in rate_law_configuration:
-                rate_law_configuration[transporter] = {
+        enzymes = specs['catalyzed by']
+        # initialize all enzymes
+        for enzyme in enzymes:
+            if enzyme not in rate_law_configuration:
+                rate_law_configuration[enzyme] = {
                     'partition': [],
                     'reaction_cofactors': {},
                 }
@@ -35,7 +35,7 @@ def make_configuration(reactions):
     # identify parameters for reactions
     for reaction_id, specs in reactions.items():
         stoich = specs.get('stoichiometry')
-        transporters = specs.get('catalyzed by', None)
+        enzymes = specs.get('catalyzed by', None)
         reversibility = specs.get('is reversible', False)
 
         # get sets of cofactors driving this reaction
@@ -46,12 +46,12 @@ def make_configuration(reactions):
             reverse_cofactors = [mol for mol, coeff in stoich.items() if coeff > 0]
             cofactors.append(reverse_cofactors)
 
-        # get partition, reactions, and parameter indices for each transporter, and save to rate_law_configuration dictionary
-        for transporter in transporters:
+        # get partition, reactions, and parameter indices for each enzyme, and save to rate_law_configuration dictionary
+        for enzyme in enzymes:
 
-            # get competition for this transporter from all other reactions
+            # get competition for this enzyme from all other reactions
             competing_reactions = [rxn for rxn, specs2 in reactions.items() if
-                    (rxn is not reaction_id) and (transporter in specs2['catalyzed by'])]
+                    (rxn is not reaction_id) and (enzyme in specs2['catalyzed by'])]
 
             competitors = []
             for reaction2 in competing_reactions:
@@ -61,8 +61,8 @@ def make_configuration(reactions):
 
             # partition includes both competitors and cofactors.
             partition = competitors + cofactors
-            rate_law_configuration[transporter]['partition'] = partition
-            rate_law_configuration[transporter]['reaction_cofactors'][reaction_id] = cofactors
+            rate_law_configuration[enzyme]['partition'] = partition
+            rate_law_configuration[enzyme]['reaction_cofactors'][reaction_id] = cofactors
 
     return rate_law_configuration
 
@@ -96,7 +96,7 @@ def make_rate_laws(reactions, rate_law_configuration, kinetic_parameters):
         reactions (dict): in the same format as all_reactions, described above
 
         rate_law_configuration (dict): with an embedded structure:
-            {transporter_id: {
+            {enzyme_id: {
                 'reaction_cofactors': {
                     reaction_id: [cofactors list]
                     }
@@ -106,41 +106,42 @@ def make_rate_laws(reactions, rate_law_configuration, kinetic_parameters):
 
         kinetic_parameters (dict): with an embedded structure:
             {reaction_id: {
-                'transporter_id': {
+                'enzyme_id': {
                     parameter_id: value
                     }
                 }
             }
 
     Returns:
-        rate_laws (dict): each reaction_id is a key and has sub-dictionary for each relevant transporter,
+        rate_laws (dict): each reaction_id is a key and has sub-dictionary for each relevant enzyme,
             with kinetic rate law functions as their values
     '''
 
-    rate_laws = {reaction_id: {} for reaction_id in reactions.iterkeys()}
+    rate_laws = {reaction_id: {} for reaction_id in list(reactions.keys())}
     for reaction_id, specs in reactions.items():
         stoichiometry = specs.get('stoichiometry')
         # reversible = specs.get('is reversible') # TODO (eran) -- add reversibility based on specs
-        transporters = specs.get('catalyzed by')
+        enzymes = specs.get('catalyzed by')
 
-        # rate law for each transporter
-        for transporter in transporters:
-            if transporter not in kinetic_parameters[reaction_id]:
+        # rate law for each enzyme
+        for enzyme in enzymes:
+            if enzyme not in kinetic_parameters[reaction_id]:
+                print('{} not in reaction {}'.format(enzyme, reaction_id))
                 continue
 
-            cofactors_sets = rate_law_configuration[transporter]["reaction_cofactors"][reaction_id]
-            partition = rate_law_configuration[transporter]["partition"]
+            cofactors_sets = rate_law_configuration[enzyme]["reaction_cofactors"][reaction_id]
+            partition = rate_law_configuration[enzyme]["partition"]
 
             rate_law = construct_convenience_rate_law(
                 stoichiometry,
-                transporter,
+                enzyme,
                 cofactors_sets,
                 partition,
-                kinetic_parameters[reaction_id][transporter]
+                kinetic_parameters[reaction_id][enzyme]
             )
 
-            # save the rate law for each transporter in this reaction
-            rate_laws[reaction_id][transporter] = rate_law
+            # save the rate law for each enzyme in this reaction
+            rate_laws[reaction_id][enzyme] = rate_law
 
     return rate_laws
 
@@ -156,13 +157,13 @@ def cofactor_denominator(concentration, km):
 
     return term
 
-def construct_convenience_rate_law(stoichiometry, transporter, cofactors_sets, partition, parameters):
+def construct_convenience_rate_law(stoichiometry, enzyme, cofactors_sets, partition, parameters):
     '''
-    Make a convenience kinetics rate law for one transporter
+    Make a convenience kinetics rate law for one enzyme
 
     Args:
         stoichiometry (dict): the stoichiometry for the given reaction
-        transporter (str): the current transporter
+        enzyme (str): the current enzyme
         cofactors_sets: a list of lists with the required cofactors, grouped by [[cofactor set 1], [cofactor set 2]], each pair needs a kcat.
         partition: a list of lists. each sublist is the set of cofactors for a given partition.
             [[C1, C2],[C3, C4], [C5]]
@@ -191,7 +192,7 @@ def construct_convenience_rate_law(stoichiometry, transporter, cofactors_sets, p
     def rate_law(concentrations):
 
         # construct numerator
-        transporter_concentration = concentrations[transporter]
+        enzyme_concentration = concentrations[enzyme]
 
         numerator = 0
         for cofactors in cofactors_sets:
@@ -215,7 +216,7 @@ def construct_convenience_rate_law(stoichiometry, transporter, cofactors_sets, p
             ])
             numerator += kcat * term  # TODO (if there is no kcat, need an exception)
 
-        numerator *= transporter_concentration
+        numerator *= enzyme_concentration
 
         # construct denominator, with all competing terms in the partition
         # denominator starts at +1 for the unbound state
@@ -250,18 +251,18 @@ class KineticFluxModel(object):
 
         kinetic_parameters (dict): a dictionary of parameters a nested format:
             {reaction_id: {
-                transporter_id : {
+                enzyme_id : {
                     param_id: param_value}}}
 
     Attributes:
-        rate_laws: a dict, with a key for each reaction id, and then subdictionaries with each reaction's transporters
+        rate_laws: a dict, with a key for each reaction id, and then subdictionaries with each reaction's enzymes
             and their rate law function. These rate laws are used directly from within this dictionary
     '''
 
     def __init__(self, all_reactions, kinetic_parameters):
 
         self.kinetic_parameters = kinetic_parameters
-        self.reaction_ids = self.kinetic_parameters.keys()
+        self.reaction_ids = list(self.kinetic_parameters.keys())
         self.reactions = {reaction_id: all_reactions[reaction_id] for reaction_id in all_reactions}
         self.molecule_ids = get_molecules(self.reactions)
 
@@ -288,9 +289,9 @@ class KineticFluxModel(object):
         # Initialize reaction_fluxes and exchange_fluxes dictionaries
         reaction_fluxes = {reaction_id: 0.0 for reaction_id in self.reaction_ids}
 
-        for reaction_id, transporters in self.rate_laws.items():
-            for transporter, rate_law in transporters.items():
-                flux = self.rate_laws[reaction_id][transporter](concentrations_dict)
+        for reaction_id, enzymes in self.rate_laws.items():
+            for enzyme, rate_law in enzymes.items():
+                flux = self.rate_laws[reaction_id][enzyme](concentrations_dict)
                 reaction_fluxes[reaction_id] += flux
 
         return reaction_fluxes


### PR DESCRIPTION
This introduces a general kinetics process based on convenience kinetics. The process uses the ```kinetics_rate_laws``` util which was originally developed for transport in wcEcoli.  It requires configuration data from ```initial_parameters```, demonstrated in the test with a ```toy_config```:

```
toy_config = {
        'reactions': toy_reactions,
        'kinetic_parameters': toy_kinetics,
        'initial_state': toy_initial_state,
        'roles': toy_roles}
```

This process will allow users to quickly configure kinetics, which can be composed with metabolism for flux constraints.  There is still some work to do before composition is quick and easy.