### PR TITLE
Providing Datum class for composite states

### DIFF
--- a/lens/states/chromosome.py
+++ b/lens/states/chromosome.py
@@ -202,7 +202,7 @@ class Chromosome(Datum):
 
 
 def test_chromosome():
-    config = {
+    chromosome_config = {
         'sequence': {
             '+': 'ATACGGCACGTG',
             '-': 'ACCGTCAACTTA'},
@@ -245,11 +245,11 @@ def test_chromosome():
                 'domain': 0,
                 'position': 0}]}
 
-    chromosome = Chromosome(config)
+    chromosome = Chromosome(chromosome_config)
     print(chromosome.transcription_factors['A'].state)
     print(chromosome.to_dict())
 
-    assert chromosome.to_dict() == config
+    assert chromosome.to_dict() == chromosome_config
 
     chromosome.initiate_replication()
     print(chromosome.to_dict()['domains'])

--- a/lens/states/chromosome.py
+++ b/lens/states/chromosome.py
@@ -1,0 +1,223 @@
+def first(l):
+    if l:
+        return l[0]
+
+def first_value(d):
+    if d:
+        return d[list(d.keys())[0]]
+
+def traverse(tree, key, f):
+    node = tree[key]
+    return f(node, [traverse(tree, child, f) for child in node.children])
+
+class Datum(object):
+    schema = {}
+
+    def __init__(self, config, default):
+        self.keys = list(set(list(config.keys()) + list(default.keys()))) # a dance
+        for key in self.keys:
+            value = config.get(key, default[key])
+            if value and key in self.schema:
+                realize = self.schema[key]
+                if isinstance(value, list):
+                    value = [realize(item) for item in value]
+                elif isinstance(value, dict):
+                    value = {inner: realize(item) for inner, item in value.items()}
+                else:
+                    value = realize(item)
+            setattr(self, key, value)
+
+    def to_dict(self):
+        to = {}
+        for key in self.keys:
+            value = getattr(self, key)
+            if isinstance(value, Datum):
+                value = value.to_dict()
+            elif value and isinstance(value, list) and isinstance(first(value), Datum):
+                value = [datum.to_dict() for datum in value]
+            elif value and isinstance(value, dict) and isinstance(first_value(value), Datum):
+                value = {inner: datum.to_dict() for inner, datum in value.items()}
+            to[key] = value
+        return to
+
+class Operon(Datum):
+    defaults = {
+        'id': '',
+        'position': 0,
+        'direction': 1,
+        'length': 0,
+        'genes': []}
+
+    def __init__(self, config):
+        super(Operon, self).__init__(config, self.defaults)
+
+class Domain(Datum):
+    defaults = {
+        'id': 0,
+        'lead': 0,
+        'lag': 0,
+        'children': []}
+
+    def __init__(self, config):
+        super(Domain, self).__init__(config, self.defaults)
+
+class TranscriptionFactor(Datum):
+    defaults = {
+        'protein': '',
+        'domain': 0,
+        'state': 0, # off
+        'operon': ''}
+
+    def __init__(self, config):
+        super(TranscriptionFactor, self).__init__(config, self.defaults)
+
+class Rnap(Datum):
+    defaults = {
+        'operon': '',
+        'domain': 0,
+        'position': 0}
+
+    def __init__(self, config):
+        super(Rnap, self).__init__(config, self.defaults)
+
+class Chromosome(Datum):
+    schema = {
+        'domains': Domain,
+        'operons': Operon,
+        'transcription_factors': TranscriptionFactor,
+        'rnaps': Rnap}
+
+    defaults = {
+        'sequence': '',
+
+        'domains': {},
+        'operons': {},
+        'transcription_factors': {},
+        'rnaps': []}
+
+    def initiate_replication(self):
+        leaves = [leaf for leaf in self.domains.values() if not leaf.children]
+        next_id = max([leaf.id for leaf in leaves]) + 1
+        for leaf in leaves:
+            for child in [0, 1]:
+                domain = Domain({'id': next_id + child})
+                self.domains[domain.id] = domain
+            leaf.children = [next_id, next_id + 1]
+            next_id += 2
+
+    def advance_replisomes(self, distances):
+        '''
+        distances is a dictionary of domain ids to tuples of how far each strand advances
+        of the form (lead, lag)
+        '''
+        # TODO: stochastically transfer rnap and tf to new domains
+
+        for key, domain in self.domains.items():
+            lead, lag = distances[key]
+            domain.lead += lead
+            domain.lag += lag
+
+    def terminate_replication(self):
+        root = min(self.domains.keys())
+        children = self.domains[root].children
+        divided = [
+            traverse(
+                self.domains,
+                child,
+                self.divide_chromosome)
+            for child in children]
+
+        return [Chromosome(fork) for fork in divided]
+
+    def divide_chromosome(self, domain, division):
+        if not division:
+            division = {
+                'sequence': self.sequence,
+                'domains': {domain.id: domain.to_dict()},
+                'operons': {id: operon.to_dict() for id, operon in self.operons.items()},
+                'transcription_factors': {
+                    operon: tf.to_dict()
+                    for operon, tf in self.transcription_factors.items()
+                    if tf.domain == domain},
+                'rnaps': [
+                    rnap.to_dict()
+                    for rnap in self.rnaps
+                    if rnap.domain == domain]}
+
+        else:
+            division.domains[domain.id] = domain
+            for operon, tf in self.transcription_factors.items():
+                if tf.domain == domain:
+                    division.transcription_factors[operon] = tf.to_dict()
+            for rnap in self.rnaps.items():
+                if rnap.domain == domain:
+                    division.rnaps.append(rnap.to_dict())
+
+        return division
+
+    def __init__(self, config):
+        super(Chromosome, self).__init__(config, self.defaults)
+
+
+def test_chromosome():
+    config = {
+        'sequence': 'ATACGGCACGTG',
+        'domains': {
+            0: {
+                'id': 0,
+                'lead': 0,
+                'lag': 0,
+                'children': []}},
+        'operons': {
+            'A': {
+                'id': 'A',
+                'position': 0,
+                'direction': 1,
+                'length': 9,
+                'genes': ['A', 'Z']},
+            'B': {
+                'id': 'B',
+                'position': 11,
+                'direction': -1,
+                'length': 3,
+                'genes': ['B']}},
+        'transcription_factors': {
+            'A': {
+                'protein': 'B',
+                'domain': 0,
+                'state': 1, # on
+                'operon': 'B'}},
+        'rnaps': [
+            {
+                'operon': 'A',
+                'domain': 0,
+                'position': 3},
+            {
+                'operon': 'A',
+                'domain': 0,
+                'position': 6},
+            {
+                'operon': 'B',
+                'domain': 0,
+                'position': 11}]}
+
+    chromosome = Chromosome(config)
+    print(chromosome.transcription_factors['A'].state)
+    print(chromosome.to_dict())
+
+    assert chromosome.to_dict() == config
+
+    chromosome.advance_replisomes({0: (3, 4)})
+    chromosome.initiate_replication()
+
+    print(chromosome.to_dict()['domains'])
+    assert len(chromosome.domains) == 3
+
+    chromosome.advance_replisomes({0: (12, 12), 1: (5, 6), 2: (4, 4)})
+    children = chromosome.terminate_replication()
+
+    print([child.to_dict() for child in children])
+
+
+if __name__ == '__main__':
+    test_chromosome()


### PR DESCRIPTION
This PR introduces a new state class/paradigm, the Datum. It can be instantiated with a dictionary, rendering all the keys in that dictionary as object attributes, operated on, then rendered back to an identical dictionary. This lets you define operations on a more complicated/composite state in object notation, while ending up with the dictionary required for state, database and serialization operations. I provide an example with a working chromosome, composed of datum definitions for its associated genes, domains, transcription factors and rnaps. Several operations are defined on this state including replication initiation, replisome advancement (distributing molecules like transcription factors and rnaps stochastically to the replicating domains), chromosome division and replication termination. 

This PR includes the cleanup commit from https://github.com/CovertLab/Lens/pull/89, when that is merged it will just be the addition of `lens/states/chromosome.py`. 